### PR TITLE
Writes last read glucose to icon badge

### DIFF
--- a/xDripG5/AppDelegate.swift
+++ b/xDripG5/AppDelegate.swift
@@ -13,6 +13,7 @@ import CoreBluetooth
 class AppDelegate: UIResponder, UIApplicationDelegate, TransmitterDelegate {
 
     var window: UIWindow?
+    var app: UIApplication!
 
     static var sharedDelegate: AppDelegate {
         return UIApplication.sharedApplication().delegate as! AppDelegate
@@ -23,6 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TransmitterDelegate {
     var transmitter: Transmitter?
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        self.app = application
 
         transmitter = Transmitter(
             ID: NSUserDefaults.standardUserDefaults().transmitterID,
@@ -31,6 +33,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TransmitterDelegate {
         )
         transmitter?.stayConnected = NSUserDefaults.standardUserDefaults().stayConnected
         transmitter?.delegate = self
+
+        self.resignFirstResponder()
+
+        // Ask user for notification because we're gonna write to the badge
+        application.registerUserNotificationSettings(UIUserNotificationSettings(forTypes: UIUserNotificationType.Badge, categories: nil))
+
+        // Clear any previous value there
+        application.applicationIconBadgeNumber = -1
+
 
         return true
     }

--- a/xDripG5/ViewController.swift
+++ b/xDripG5/ViewController.swift
@@ -103,10 +103,18 @@ class ViewController: UIViewController, TransmitterDelegate, UITextFieldDelegate
         titleLabel.text = NSLocalizedString("Error", comment: "Title displayed during error response")
 
         subtitleLabel.text = "\(error)"
+
+        // get the app and clear the badge value
+        let appDelegate = UIApplication.sharedApplication().delegate as! AppDelegate
+        appDelegate.app.applicationIconBadgeNumber = -1
     }
 
     func transmitter(transmitter: Transmitter, didReadGlucose glucose: GlucoseRxMessage) {
         titleLabel.text = NSNumberFormatter.localizedStringFromNumber(NSNumber(short: Int16(glucose.glucose)), numberStyle: .NoStyle)
+
+        // get the app and set the badge value to the current glucose reading
+        let appDelegate = UIApplication.sharedApplication().delegate as! AppDelegate
+        appDelegate.app.applicationIconBadgeNumber = Int(glucose.glucose)
 
         if let startTime = transmitter.startTimeInterval {
             let date = NSDate(timeIntervalSince1970: startTime).dateByAddingTimeInterval(NSTimeInterval(glucose.timestamp))
@@ -115,7 +123,7 @@ class ViewController: UIViewController, TransmitterDelegate, UITextFieldDelegate
         } else {
             subtitleLabel.text = "Unknown time"
         }
-
+        
     }
 
 }


### PR DESCRIPTION
If able to read a glucose value then will write it to the app badge. If error in reading then clears badge.

Nothing fancy here but thought I'd share with you what I added today.