### PR TITLE
Allow Xcode warnings in podspec validation for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ podfile: Example/Podfile
 
 script:
 - set -o pipefail && xcodebuild test -workspace Example/xDripG5.xcworkspace -scheme xDripG5-Example -sdk iphonesimulator -destination name="iPhone 6" ONLY_ACTIVE_ARCH=NO | xcpretty
-- pod lib lint
+- pod lib lint --allow-warnings


### PR DESCRIPTION
This is a swift bridging issue documented here: https://github.com/RNCryptor/RNCryptor/issues/166