### PR TITLE
Convert Transmitter to a protocol

### DIFF
--- a/xDripG5.xcodeproj/project.pbxproj
+++ b/xDripG5.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		43CABE121C350B2800005705 /* BluetoothManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CABE0E1C350B2800005705 /* BluetoothManager.swift */; };
 		43CABE131C350B2800005705 /* BluetoothServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CABE0F1C350B2800005705 /* BluetoothServices.swift */; };
 		43CABE141C350B2800005705 /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CABE101C350B2800005705 /* NSData.swift */; };
-		43CABE151C350B2800005705 /* Transmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CABE111C350B2800005705 /* Transmitter.swift */; };
 		43CABE231C350B3D00005705 /* AuthChallengeRxMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CABE171C350B3D00005705 /* AuthChallengeRxMessage.swift */; };
 		43CABE241C350B3D00005705 /* AuthChallengeTxMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CABE181C350B3D00005705 /* AuthChallengeTxMessage.swift */; };
 		43CABE251C350B3D00005705 /* AuthRequestTxMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CABE191C350B3D00005705 /* AuthRequestTxMessage.swift */; };
@@ -29,6 +28,8 @@
 		43CABE2C1C350B3D00005705 /* TransmitterMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CABE201C350B3D00005705 /* TransmitterMessage.swift */; };
 		43CABE2D1C350B3D00005705 /* TransmitterTimeRxMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CABE211C350B3D00005705 /* TransmitterTimeRxMessage.swift */; };
 		43CABE2E1C350B3D00005705 /* TransmitterTimeTxMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CABE221C350B3D00005705 /* TransmitterTimeTxMessage.swift */; };
+		956BF8FE1C4526F7005A2723 /* Transmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956BF8FD1C4526F7005A2723 /* Transmitter.swift */; };
+		956BF9011C452DF3005A2723 /* G5Transmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956BF9001C452DF3005A2723 /* G5Transmitter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,7 +66,6 @@
 		43CABE0E1C350B2800005705 /* BluetoothManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BluetoothManager.swift; sourceTree = "<group>"; };
 		43CABE0F1C350B2800005705 /* BluetoothServices.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BluetoothServices.swift; sourceTree = "<group>"; };
 		43CABE101C350B2800005705 /* NSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSData.swift; sourceTree = "<group>"; };
-		43CABE111C350B2800005705 /* Transmitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transmitter.swift; sourceTree = "<group>"; };
 		43CABE171C350B3D00005705 /* AuthChallengeRxMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthChallengeRxMessage.swift; sourceTree = "<group>"; };
 		43CABE181C350B3D00005705 /* AuthChallengeTxMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthChallengeTxMessage.swift; sourceTree = "<group>"; };
 		43CABE191C350B3D00005705 /* AuthRequestTxMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthRequestTxMessage.swift; sourceTree = "<group>"; };
@@ -78,6 +78,8 @@
 		43CABE201C350B3D00005705 /* TransmitterMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransmitterMessage.swift; sourceTree = "<group>"; };
 		43CABE211C350B3D00005705 /* TransmitterTimeRxMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransmitterTimeRxMessage.swift; sourceTree = "<group>"; };
 		43CABE221C350B3D00005705 /* TransmitterTimeTxMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransmitterTimeTxMessage.swift; sourceTree = "<group>"; };
+		956BF8FD1C4526F7005A2723 /* Transmitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transmitter.swift; sourceTree = "<group>"; };
+		956BF9001C452DF3005A2723 /* G5Transmitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = G5Transmitter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,7 +130,8 @@
 				43CABE0E1C350B2800005705 /* BluetoothManager.swift */,
 				43CABE0F1C350B2800005705 /* BluetoothServices.swift */,
 				43CABE101C350B2800005705 /* NSData.swift */,
-				43CABE111C350B2800005705 /* Transmitter.swift */,
+				956BF8FD1C4526F7005A2723 /* Transmitter.swift */,
+				956BF9001C452DF3005A2723 /* G5Transmitter.swift */,
 				43CABE161C350B2E00005705 /* Messages */,
 			);
 			path = xDripG5;
@@ -272,6 +275,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				43CABE2D1C350B3D00005705 /* TransmitterTimeRxMessage.swift in Sources */,
+				956BF9011C452DF3005A2723 /* G5Transmitter.swift in Sources */,
 				43CABE291C350B3D00005705 /* GlucoseRxMessage.swift in Sources */,
 				43CABE271C350B3D00005705 /* BondRequestTxMessage.swift in Sources */,
 				43CABE231C350B3D00005705 /* AuthChallengeRxMessage.swift in Sources */,
@@ -280,10 +284,10 @@
 				43CABE2E1C350B3D00005705 /* TransmitterTimeTxMessage.swift in Sources */,
 				43CABE2C1C350B3D00005705 /* TransmitterMessage.swift in Sources */,
 				43CABE131C350B2800005705 /* BluetoothServices.swift in Sources */,
-				43CABE151C350B2800005705 /* Transmitter.swift in Sources */,
 				43CABE281C350B3D00005705 /* DisconnectTxMessage.swift in Sources */,
 				43CABE141C350B2800005705 /* NSData.swift in Sources */,
 				43CABE121C350B2800005705 /* BluetoothManager.swift in Sources */,
+				956BF8FE1C4526F7005A2723 /* Transmitter.swift in Sources */,
 				43CABE2B1C350B3D00005705 /* KeepAliveTxMessage.swift in Sources */,
 				43CABE241C350B3D00005705 /* AuthChallengeTxMessage.swift in Sources */,
 				43CABE251C350B3D00005705 /* AuthRequestTxMessage.swift in Sources */,

--- a/xDripG5/G5Transmitter.swift
+++ b/xDripG5/G5Transmitter.swift
@@ -1,0 +1,265 @@
+//
+//  G5Sensor.swift
+//  xDripG5
+//
+//  Created by Dennis Gove on 1/12/16.
+//  Copyright © 2016 Nathan Racklyeft. All rights reserved.
+//
+
+import Foundation
+
+public class G5Transmitter: BluetoothManagerDelegate, Transmitter {
+
+    public var transmitterId: String
+    private var passiveModeEnabled: Bool
+
+    private var transmitterDelegate: TransmitterDelegate?
+
+    // Bluetoothy things
+    private let bluetoothManager = BluetoothManager()
+    private var operationQueue = dispatch_queue_create("com.loudnate.xDripG5.transmitterOperationQueue", DISPATCH_QUEUE_SERIAL)
+
+    public init(transmitterId: String, passiveModeEnabled: Bool = false) {
+        self.transmitterId = transmitterId
+        self.passiveModeEnabled = passiveModeEnabled
+
+        bluetoothManager.delegate = self
+    }
+
+    public var delegate: TransmitterDelegate? {
+        get{
+            return transmitterDelegate
+        }
+        set{
+            transmitterDelegate = newValue
+        }
+    }
+
+    public func resumeScanning() {
+        if stayConnected {
+            bluetoothManager.scanForPeripheral()
+        }
+    }
+
+    public func stopScanning() {
+        bluetoothManager.disconnect()
+    }
+
+    public var isScanning: Bool {
+        return bluetoothManager.isScanning
+    }
+
+    public var stayConnected: Bool {
+        get {
+            return bluetoothManager.stayConnected
+        }
+        set {
+            bluetoothManager.stayConnected = newValue
+
+            if newValue {
+                bluetoothManager.scanForPeripheral()
+            }
+        }
+    }
+
+    // MARK: - BluetoothManagerDelegate
+
+    func bluetoothManager(manager: BluetoothManager, isReadyWithError error: NSError?) {
+        if let error = error {
+            self.delegate?.transmitter(self, didError: error)
+            return
+        }
+
+        dispatch_async(operationQueue) {
+            if self.passiveModeEnabled {
+                do {
+                    try self.listenToControl()
+                } catch let error {
+                    self.delegate?.transmitter(self, didError: error)
+                }
+            } else {
+                do {
+                    try self.authenticate()
+                    try self.control()
+                } catch let error {
+                    manager.disconnect()
+
+                    self.delegate?.transmitter(self, didError: error)
+                }
+            }
+        }
+    }
+
+
+    // MARK: - Helpers
+
+    private func authenticate() throws {
+        if let data = try? bluetoothManager.readValueForCharacteristicAndWait(.Authentication),
+            status = AuthStatusRxMessage(data: data) where status.authenticated == 1 && status.bonded == 1
+        {
+            NSLog("Transmitter already authenticated.")
+        } else {
+            do {
+                try bluetoothManager.setNotifyEnabledAndWait(true, forCharacteristicUUID: .Authentication)
+            } catch let error {
+                throw TransmitterError.AuthenticationError("Error enabling notification: \(error)")
+            }
+
+            let authMessage = AuthRequestTxMessage()
+            let data: NSData
+
+            do {
+                data = try bluetoothManager.writeValueAndWait(authMessage.data, forCharacteristicUUID: .Authentication, expectingFirstByte: AuthChallengeRxMessage.opcode)
+            } catch let error {
+                throw TransmitterError.AuthenticationError("Error writing transmitter challenge: \(error)")
+            }
+
+            guard let response = AuthChallengeRxMessage(data: data) else {
+                throw TransmitterError.AuthenticationError("Unable to parse auth challenge: \(data)")
+            }
+
+            guard response.tokenHash == self.calculateHash(authMessage.singleUseToken) else {
+                throw TransmitterError.AuthenticationError("Transmitter failed auth challenge")
+            }
+
+            if let challengeHash = self.calculateHash(response.challenge) {
+                let data: NSData
+                do {
+                    data = try bluetoothManager.writeValueAndWait(AuthChallengeTxMessage(challengeHash: challengeHash).data, forCharacteristicUUID: .Authentication, expectingFirstByte: AuthStatusRxMessage.opcode)
+                } catch let error {
+                    throw TransmitterError.AuthenticationError("Error writing challenge response: \(error)")
+                }
+
+                guard let response = AuthStatusRxMessage(data: data) else {
+                    throw TransmitterError.AuthenticationError("Unable to parse auth status: \(data)")
+                }
+
+                guard response.authenticated == 1 else {
+                    throw TransmitterError.AuthenticationError("Transmitter rejected auth challenge")
+                }
+
+                if response.bonded != 0x1 {
+                    do {
+                        try bluetoothManager.writeValueAndWait(KeepAliveTxMessage(time: 25).data, forCharacteristicUUID: .Authentication)
+                    } catch let error {
+                        throw TransmitterError.AuthenticationError("Error writing keep-alive for bond: \(error)")
+                    }
+
+                    let data: NSData
+                    do {
+                        // Wait for the OS dialog to pop-up before continuing.
+                        data = try bluetoothManager.writeValueAndWait(BondRequestTxMessage().data, forCharacteristicUUID: .Authentication, timeout: 15, expectingFirstByte: AuthStatusRxMessage.opcode)
+                    } catch let error {
+                        throw TransmitterError.AuthenticationError("Error writing bond request: \(error)")
+                    }
+
+                    guard let response = AuthStatusRxMessage(data: data) else {
+                        throw TransmitterError.AuthenticationError("Unable to parse auth status: \(data)")
+                    }
+
+                    guard response.bonded == 0x1 else {
+                        throw TransmitterError.AuthenticationError("Transmitter failed to bond")
+                    }
+                }
+            }
+
+            do {
+                try bluetoothManager.setNotifyEnabledAndWait(false, forCharacteristicUUID: .Authentication)
+            } catch let error {
+                throw TransmitterError.AuthenticationError("Error disabling notification: \(error)")
+            }
+        }
+    }
+
+    private func control() throws {
+        do {
+            try bluetoothManager.setNotifyEnabledAndWait(true, forCharacteristicUUID: .Control)
+        } catch let error {
+            throw TransmitterError.ControlError("Error enabling notification: \(error)")
+        }
+
+        let glucoseData: NSData
+        do {
+            glucoseData = try bluetoothManager.writeValueAndWait(GlucoseTxMessage().data, forCharacteristicUUID: .Control, expectingFirstByte: G5GlucoseRxMessage.opcode)
+        } catch let error {
+            throw TransmitterError.ControlError("Error writing glucose request: \(error)")
+        }
+
+        guard let glucoseMessage = G5GlucoseRxMessage(data: glucoseData) else {
+            throw TransmitterError.ControlError("Unable to parse glucose response: \(glucoseData)")
+        }
+
+        self.delegate?.transmitter(self, didReadGlucose: glucoseMessage)
+
+        do {
+            try bluetoothManager.setNotifyEnabledAndWait(false, forCharacteristicUUID: .Control)
+            try bluetoothManager.writeValueAndWait(DisconnectTxMessage().data, forCharacteristicUUID: .Control)
+        } catch {
+        }
+    }
+
+    private func listenToControl() throws {
+        do {
+            try bluetoothManager.setNotifyEnabledAndWait(true, forCharacteristicUUID: .Control)
+        } catch let error {
+            throw TransmitterError.ControlError("Error enabling notification: \(error)")
+        }
+
+        let timeData: NSData
+        do {
+            timeData = try bluetoothManager.waitForCharacteristicValueUpdate(.Control, expectingFirstByte: TransmitterTimeRxMessage.opcode)
+        } catch let error {
+            throw TransmitterError.ControlError("Error waiting for time response: \(error)")
+        }
+
+        guard let timeMessage = TransmitterTimeRxMessage(data: timeData) else {
+            throw TransmitterError.ControlError("Unable to parse time response: \(timeData)")
+        }
+
+        let glucoseData: NSData
+        do {
+            glucoseData = try bluetoothManager.waitForCharacteristicValueUpdate(.Control, expectingFirstByte: G5GlucoseRxMessage.opcode)
+        } catch let error {
+            throw TransmitterError.ControlError("Error waiting for glucose response: \(error)")
+        }
+
+        guard let glucoseMessage = G5GlucoseRxMessage(data: glucoseData) else {
+            throw TransmitterError.ControlError("Unable to parse glucose response: \(glucoseData)")
+        }
+
+        self.delegate?.transmitter(self, didReadGlucose: glucoseMessage)
+    }
+
+    private var cryptKey: NSData? {
+        return "00\(transmitterId)00\(transmitterId)".dataUsingEncoding(NSUTF8StringEncoding)
+    }
+
+    private func calculateHash(data: NSData) -> NSData? {
+        guard data.length == 8, let key = cryptKey, outData = NSMutableData(length: 16) else {
+            return nil
+        }
+
+        let doubleData = NSMutableData(data: data)
+        doubleData.appendData(data)
+
+        let status = CCCrypt(
+            0, // kCCEncrypt
+            0, // kCCAlgorithmAES
+            0x0002, // kCCOptionECBMode
+            key.bytes,
+            key.length,
+            nil,
+            doubleData.bytes,
+            doubleData.length,
+            outData.mutableBytes,
+            outData.length,
+            nil
+        )
+        
+        if status != 0 { // kCCSuccess
+            return nil
+        } else {
+            return outData[0..<8]
+        }
+    }
+}

--- a/xDripG5/Messages/G5GlucoseRxMessage.swift
+++ b/xDripG5/Messages/G5GlucoseRxMessage.swift
@@ -1,0 +1,51 @@
+//
+//  G5GlucoseRxMessage.swift
+//  xDrip5
+//
+//  Created by Nathan Racklyeft on 11/23/15.
+//  Copyright © 2015 Nathan Racklyeft. All rights reserved.
+//
+
+import Foundation
+
+
+public struct G5GlucoseRxMessage: GlucoseRxMessage {
+    static let opcode: UInt8 = 0x31
+    let glucoseIsDisplayOnly: Bool = false  // TODO
+    let status: UInt8
+    let sequence: UInt32
+    var glucoseValue: UInt16
+    public let timestamp: UInt32
+    public let state: UInt8
+    public let trend: Int8
+
+    public var glucose: UInt16{
+        get{ return self.glucoseValue }
+        set{ self.glucoseValue = newValue }
+    }
+
+    public init?(data: NSData) {
+        if data.length >= 14 {
+            if data[0] == self.dynamicType.opcode {
+                status = data[1]
+                sequence = data[2...5]
+                timestamp = data[6...9]
+                glucoseValue = data[10...11] & 0xfff
+                state = data[12]
+                trend = data[13]
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+    }
+}
+
+
+extension G5GlucoseRxMessage: Equatable {
+}
+
+public func ==(lhs: G5GlucoseRxMessage, rhs: G5GlucoseRxMessage) -> Bool {
+    return lhs.sequence == rhs.sequence
+}

--- a/xDripG5/Messages/GlucoseRxMessage.swift
+++ b/xDripG5/Messages/GlucoseRxMessage.swift
@@ -8,39 +8,10 @@
 
 import Foundation
 
-
-public struct GlucoseRxMessage: TransmitterRxMessage {
-    static let opcode: UInt8 = 0x31
-    let glucoseIsDisplayOnly: Bool = false  // TODO
-    let status: UInt8
-    let sequence: UInt32
-    public let timestamp: UInt32
-    public let glucose: UInt16
-    public let state: UInt8
-    public let trend: Int8
-
-    init?(data: NSData) {
-        if data.length >= 14 {
-            if data[0] == self.dynamicType.opcode {
-                status = data[1]
-                sequence = data[2...5]
-                timestamp = data[6...9]
-                glucose = data[10...11] & 0xfff
-                state = data[12]
-                trend = data[13]
-            } else {
-                return nil
-            }
-        } else {
-            return nil
-        }
+public protocol GlucoseRxMessage: TransmitterRxMessage {
+    var glucose: UInt16 {
+        get
+        set
     }
-}
 
-
-extension GlucoseRxMessage: Equatable {
-}
-
-public func ==(lhs: GlucoseRxMessage, rhs: GlucoseRxMessage) -> Bool {
-    return lhs.sequence == rhs.sequence
 }

--- a/xDripG5/Messages/TransmitterMessage.swift
+++ b/xDripG5/Messages/TransmitterMessage.swift
@@ -52,7 +52,7 @@ extension TransmitterTxMessage {
 }
 
 
-protocol TransmitterRxMessage {
+public protocol TransmitterRxMessage {
 
     init?(data: NSData)
 

--- a/xDripG5/Transmitter.swift
+++ b/xDripG5/Transmitter.swift
@@ -8,283 +8,44 @@
 
 import Foundation
 
-
 public protocol TransmitterDelegate: class {
-
     func transmitter(transmitter: Transmitter, didReadGlucose glucose: GlucoseRxMessage)
-
     func transmitter(transmitter: Transmitter, didError error: ErrorType)
 }
-
 
 public enum TransmitterError: ErrorType {
     case AuthenticationError(String)
     case ControlError(String)
 }
 
+public protocol Transmitter: class {
 
-public class Transmitter: BluetoothManagerDelegate {
-    public var ID: String
-
-    public var startTimeInterval: NSTimeInterval?
-
-    public var passiveModeEnabled: Bool
-
-    public weak var delegate: TransmitterDelegate?
-
-    private let bluetoothManager = BluetoothManager()
-
-    private var operationQueue = dispatch_queue_create("com.loudnate.xDripG5.transmitterOperationQueue", DISPATCH_QUEUE_SERIAL)
-
-    public init(ID: String, startTimeInterval: NSTimeInterval?, passiveModeEnabled: Bool = false) {
-        self.ID = ID
-        self.startTimeInterval = startTimeInterval
-        self.passiveModeEnabled = passiveModeEnabled
-
-        bluetoothManager.delegate = self
+    // Id of transmitter
+    var transmitterId: String {
+        get
     }
 
-    public func resumeScanning() {
-        if stayConnected {
-            bluetoothManager.scanForPeripheral()
-        }
+    var delegate: TransmitterDelegate? {
+        get
+        set
     }
 
-    public func stopScanning() {
-        bluetoothManager.disconnect()
+
+    // getter to know if the transmitter is scanning for values
+    var isScanning: Bool {
+        get
     }
 
-    public var isScanning: Bool {
-        return bluetoothManager.isScanning
+    // getter/setter to know if transmitter should stay connected when the app is inactive
+    var stayConnected: Bool {
+        get
+        set
     }
 
-    public var stayConnected: Bool {
-        get {
-            return bluetoothManager.stayConnected
-        }
-        set {
-            bluetoothManager.stayConnected = newValue
+    // Stop scanning for values
+    func stopScanning()
 
-            if newValue {
-                bluetoothManager.scanForPeripheral()
-            }
-        }
-    }
+    // Resume (or start) scanning for values
+    func resumeScanning()
 
-    // MARK: - BluetoothManagerDelegate
-
-    func bluetoothManager(manager: BluetoothManager, isReadyWithError error: NSError?) {
-        if let error = error {
-            self.delegate?.transmitter(self, didError: error)
-            return
-        }
-
-        dispatch_async(operationQueue) {
-            if self.passiveModeEnabled {
-                do {
-                    try self.listenToControl()
-                } catch let error {
-                    self.delegate?.transmitter(self, didError: error)
-                }
-            } else {
-                do {
-                    try self.authenticate()
-                    try self.control()
-                } catch let error {
-                    manager.disconnect()
-
-                    self.delegate?.transmitter(self, didError: error)
-                }
-            }
-        }
-    }
-
-    // MARK: - Helpers
-
-    private func authenticate() throws {
-        if let data = try? bluetoothManager.readValueForCharacteristicAndWait(.Authentication),
-            status = AuthStatusRxMessage(data: data) where status.authenticated == 1 && status.bonded == 1
-        {
-            NSLog("Transmitter already authenticated.")
-        } else {
-            do {
-                try bluetoothManager.setNotifyEnabledAndWait(true, forCharacteristicUUID: .Authentication)
-            } catch let error {
-                throw TransmitterError.AuthenticationError("Error enabling notification: \(error)")
-            }
-
-            let authMessage = AuthRequestTxMessage()
-            let data: NSData
-
-            do {
-                data = try bluetoothManager.writeValueAndWait(authMessage.data, forCharacteristicUUID: .Authentication, expectingFirstByte: AuthChallengeRxMessage.opcode)
-            } catch let error {
-                throw TransmitterError.AuthenticationError("Error writing transmitter challenge: \(error)")
-            }
-
-            guard let response = AuthChallengeRxMessage(data: data) else {
-                throw TransmitterError.AuthenticationError("Unable to parse auth challenge: \(data)")
-            }
-
-            guard response.tokenHash == self.calculateHash(authMessage.singleUseToken) else {
-                throw TransmitterError.AuthenticationError("Transmitter failed auth challenge")
-            }
-
-            if let challengeHash = self.calculateHash(response.challenge) {
-                let data: NSData
-                do {
-                    data = try bluetoothManager.writeValueAndWait(AuthChallengeTxMessage(challengeHash: challengeHash).data, forCharacteristicUUID: .Authentication, expectingFirstByte: AuthStatusRxMessage.opcode)
-                } catch let error {
-                    throw TransmitterError.AuthenticationError("Error writing challenge response: \(error)")
-                }
-
-                guard let response = AuthStatusRxMessage(data: data) else {
-                    throw TransmitterError.AuthenticationError("Unable to parse auth status: \(data)")
-                }
-
-                guard response.authenticated == 1 else {
-                    throw TransmitterError.AuthenticationError("Transmitter rejected auth challenge")
-                }
-
-                if response.bonded != 0x1 {
-                    do {
-                        try bluetoothManager.writeValueAndWait(KeepAliveTxMessage(time: 25).data, forCharacteristicUUID: .Authentication)
-                    } catch let error {
-                        throw TransmitterError.AuthenticationError("Error writing keep-alive for bond: \(error)")
-                    }
-
-                    let data: NSData
-                    do {
-                        // Wait for the OS dialog to pop-up before continuing.
-                        data = try bluetoothManager.writeValueAndWait(BondRequestTxMessage().data, forCharacteristicUUID: .Authentication, timeout: 15, expectingFirstByte: AuthStatusRxMessage.opcode)
-                    } catch let error {
-                        throw TransmitterError.AuthenticationError("Error writing bond request: \(error)")
-                    }
-
-                    guard let response = AuthStatusRxMessage(data: data) else {
-                        throw TransmitterError.AuthenticationError("Unable to parse auth status: \(data)")
-                    }
-
-                    guard response.bonded == 0x1 else {
-                        throw TransmitterError.AuthenticationError("Transmitter failed to bond")
-                    }
-                }
-            }
-
-            do {
-                try bluetoothManager.setNotifyEnabledAndWait(false, forCharacteristicUUID: .Authentication)
-            } catch let error {
-                throw TransmitterError.AuthenticationError("Error disabling notification: \(error)")
-            }
-        }
-    }
-
-    private func control() throws {
-        do {
-            try bluetoothManager.setNotifyEnabledAndWait(true, forCharacteristicUUID: .Control)
-        } catch let error {
-            throw TransmitterError.ControlError("Error enabling notification: \(error)")
-        }
-
-        if startTimeInterval == nil {
-            let timeData: NSData
-            do {
-                timeData = try bluetoothManager.writeValueAndWait(TransmitterTimeTxMessage().data, forCharacteristicUUID: .Control, expectingFirstByte: TransmitterTimeRxMessage.opcode)
-            } catch let error {
-                throw TransmitterError.ControlError("Error writing time request: \(error)")
-            }
-
-            guard let timeMessage = TransmitterTimeRxMessage(data: timeData) else {
-                throw TransmitterError.ControlError("Unable to parse time response: \(timeData)")
-            }
-
-            self.startTimeInterval = NSDate().timeIntervalSince1970 - NSTimeInterval(timeMessage.currentTime)
-        }
-
-        let glucoseData: NSData
-        do {
-            glucoseData = try bluetoothManager.writeValueAndWait(GlucoseTxMessage().data, forCharacteristicUUID: .Control, expectingFirstByte: GlucoseRxMessage.opcode)
-        } catch let error {
-            throw TransmitterError.ControlError("Error writing glucose request: \(error)")
-        }
-
-        guard let glucoseMessage = GlucoseRxMessage(data: glucoseData) else {
-            throw TransmitterError.ControlError("Unable to parse glucose response: \(glucoseData)")
-        }
-
-        self.delegate?.transmitter(self, didReadGlucose: glucoseMessage)
-
-        do {
-            try bluetoothManager.setNotifyEnabledAndWait(false, forCharacteristicUUID: .Control)
-            try bluetoothManager.writeValueAndWait(DisconnectTxMessage().data, forCharacteristicUUID: .Control)
-        } catch {
-        }
-    }
-
-    private func listenToControl() throws {
-        do {
-            try bluetoothManager.setNotifyEnabledAndWait(true, forCharacteristicUUID: .Control)
-        } catch let error {
-            throw TransmitterError.ControlError("Error enabling notification: \(error)")
-        }
-
-        let timeData: NSData
-        do {
-            timeData = try bluetoothManager.waitForCharacteristicValueUpdate(.Control, expectingFirstByte: TransmitterTimeRxMessage.opcode)
-        } catch let error {
-            throw TransmitterError.ControlError("Error waiting for time response: \(error)")
-        }
-
-        guard let timeMessage = TransmitterTimeRxMessage(data: timeData) else {
-            throw TransmitterError.ControlError("Unable to parse time response: \(timeData)")
-        }
-
-        self.startTimeInterval = NSDate().timeIntervalSince1970 - NSTimeInterval(timeMessage.currentTime)
-
-        let glucoseData: NSData
-        do {
-            glucoseData = try bluetoothManager.waitForCharacteristicValueUpdate(.Control, expectingFirstByte: GlucoseRxMessage.opcode)
-        } catch let error {
-            throw TransmitterError.ControlError("Error waiting for glucose response: \(error)")
-        }
-
-        guard let glucoseMessage = GlucoseRxMessage(data: glucoseData) else {
-            throw TransmitterError.ControlError("Unable to parse glucose response: \(glucoseData)")
-        }
-
-        self.delegate?.transmitter(self, didReadGlucose: glucoseMessage)
-    }
-
-    private var cryptKey: NSData? {
-        return "00\(ID)00\(ID)".dataUsingEncoding(NSUTF8StringEncoding)
-    }
-
-    private func calculateHash(data: NSData) -> NSData? {
-        guard data.length == 8, let key = cryptKey, outData = NSMutableData(length: 16) else {
-            return nil
-        }
-
-        let doubleData = NSMutableData(data: data)
-        doubleData.appendData(data)
-
-        let status = CCCrypt(
-            0, // kCCEncrypt
-            0, // kCCAlgorithmAES
-            0x0002, // kCCOptionECBMode
-            key.bytes,
-            key.length,
-            nil,
-            doubleData.bytes,
-            doubleData.length,
-            outData.mutableBytes,
-            outData.length,
-            nil
-        )
-
-        if status != 0 { // kCCSuccess
-            return nil
-        } else {
-            return outData[0..<8]
-        }
-    }
 }


### PR DESCRIPTION
The goal here is to convert Transmitter to a proper protocol so one can create test
Transmitter instances. To do this a new class, G5Transmitter, is created which
implements the Transmitter protocol specific to a G5 transmitter (ie, bluetooth).

Making this change allows me to implement, for tests, a non-bluetooth dependent
Transmitter to greatly simplify my testing.