### PR TITLE
Match advertised name to transmitter ID before connecting

### DIFF
--- a/xDripG5/BluetoothManager.swift
+++ b/xDripG5/BluetoothManager.swift
@@ -28,7 +28,7 @@ protocol BluetoothManagerDelegate: class {
 
      - returns: True if the peripheral should connect
      */
-    func bluetoothManager(manager: BluetoothManager, shouldConnectToPeripheral peripheral: CBPeripheral) -> Bool
+    func bluetoothManager(manager: BluetoothManager, shouldConnectPeripheral peripheral: CBPeripheral) -> Bool
 }
 
 
@@ -311,7 +311,7 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate
     func centralManager(central: CBCentralManager, willRestoreState dict: [String : AnyObject]) {
         if peripheral == nil, let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] {
             for peripheral in peripherals {
-                if delegate == nil || delegate!.bluetoothManager(self, shouldConnectToPeripheral: peripheral) {
+                if delegate == nil || delegate!.bluetoothManager(self, shouldConnectPeripheral: peripheral) {
                     self.peripheral = peripheral
                     peripheral.delegate = self
                 }
@@ -321,7 +321,7 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate
 
     func centralManager(central: CBCentralManager, didDiscoverPeripheral peripheral: CBPeripheral, advertisementData: [String : AnyObject], RSSI: NSNumber) {
 
-        if delegate == nil || delegate!.bluetoothManager(self, shouldConnectToPeripheral: peripheral) {
+        if delegate == nil || delegate!.bluetoothManager(self, shouldConnectPeripheral: peripheral) {
             self.peripheral = peripheral
             peripheral.delegate = self
 

--- a/xDripG5/BluetoothManager.swift
+++ b/xDripG5/BluetoothManager.swift
@@ -11,7 +11,24 @@ import Foundation
 
 
 protocol BluetoothManagerDelegate: class {
+
+    /**
+     Tells the delegate that the bluetooth manager has finished connecting to and discovering all required services of its peripheral, or that it failed to do so
+
+     - parameter manager: The bluetooth manager
+     - parameter error:   An error describing why bluetooth setup failed
+     */
     func bluetoothManager(manager: BluetoothManager, isReadyWithError error: NSError?)
+
+    /**
+     Asks the delegate whether the discovered or restored peripheral should be connected
+
+     - parameter manager:    The bluetooth manager
+     - parameter peripheral: The found peripheral
+
+     - returns: True if the peripheral should connect
+     */
+    func bluetoothManager(manager: BluetoothManager, shouldConnectToPeripheral peripheral: CBPeripheral) -> Bool
 }
 
 
@@ -294,21 +311,24 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate
     func centralManager(central: CBCentralManager, willRestoreState dict: [String : AnyObject]) {
         if peripheral == nil, let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] {
             for peripheral in peripherals {
-
-                self.peripheral = peripheral
-                peripheral.delegate = self
+                if delegate == nil || delegate!.bluetoothManager(self, shouldConnectToPeripheral: peripheral) {
+                    self.peripheral = peripheral
+                    peripheral.delegate = self
+                }
             }
         }
     }
 
     func centralManager(central: CBCentralManager, didDiscoverPeripheral peripheral: CBPeripheral, advertisementData: [String : AnyObject], RSSI: NSNumber) {
 
-        self.peripheral = peripheral
-        peripheral.delegate = self
+        if delegate == nil || delegate!.bluetoothManager(self, shouldConnectToPeripheral: peripheral) {
+            self.peripheral = peripheral
+            peripheral.delegate = self
 
-        central.connectPeripheral(peripheral, options: nil)
+            central.connectPeripheral(peripheral, options: nil)
 
-        central.stopScan()
+            central.stopScan()
+        }
     }
 
     func centralManager(central: CBCentralManager, didConnectPeripheral peripheral: CBPeripheral) {

--- a/xDripG5/Transmitter.swift
+++ b/xDripG5/Transmitter.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreBluetooth
 
 
 public protocol TransmitterDelegate: class {
@@ -24,6 +25,7 @@ public enum TransmitterError: ErrorType {
 
 
 public class Transmitter: BluetoothManagerDelegate {
+
     public var ID: String
 
     public var startTimeInterval: NSTimeInterval?
@@ -96,6 +98,28 @@ public class Transmitter: BluetoothManagerDelegate {
                     self.delegate?.transmitter(self, didError: error)
                 }
             }
+        }
+    }
+
+    /**
+     Convenience helper for getting a substring of the last two characters of a string.
+     
+     The Dexcom G5 advertises a peripheral name of "DexcomXX" where "XX" is the last-two characters
+     of the transmitter ID.
+
+     - parameter string: The string to parse
+
+     - returns: A new string, containing the last two characters of the input string
+     */
+    private func lastTwoCharactersOfString(string: String) -> String {
+        return string.substringFromIndex(string.endIndex.advancedBy(-2, limit: string.startIndex))
+    }
+
+    func bluetoothManager(manager: BluetoothManager, shouldConnectToPeripheral peripheral: CBPeripheral) -> Bool {
+        if let name = peripheral.name where lastTwoCharactersOfString(name) == lastTwoCharactersOfString(ID) {
+            return true
+        } else {
+            return false
         }
     }
 

--- a/xDripG5/Transmitter.swift
+++ b/xDripG5/Transmitter.swift
@@ -115,7 +115,7 @@ public class Transmitter: BluetoothManagerDelegate {
         return string.substringFromIndex(string.endIndex.advancedBy(-2, limit: string.startIndex))
     }
 
-    func bluetoothManager(manager: BluetoothManager, shouldConnectToPeripheral peripheral: CBPeripheral) -> Bool {
+    func bluetoothManager(manager: BluetoothManager, shouldConnectPeripheral peripheral: CBPeripheral) -> Bool {
         if let name = peripheral.name where lastTwoCharactersOfString(name) == lastTwoCharactersOfString(ID) {
             return true
         } else {


### PR DESCRIPTION
Fixes #8, for two important use cases:
* Two active G5 transmitters in the same room
* Changeover from one transmitter to another