### PR TITLE
Filter the services array to just the CGM service

### DIFF
--- a/xDripG5/BluetoothManager.swift
+++ b/xDripG5/BluetoothManager.swift
@@ -364,7 +364,7 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate
     // MARK: - CBPeripheralDelegate
 
     func peripheral(peripheral: CBPeripheral, didDiscoverServices error: NSError?) {
-        for service in peripheral.services ?? [] {
+        for service in peripheral.services ?? [] where service.UUID.UUIDString == TransmitterServiceUUID.CGMService.rawValue {
             var characteristicsToDiscover = [CBUUID]()
             let knownCharacteristics = service.characteristics?.flatMap({ $0.UUID }) ?? []
 


### PR DESCRIPTION
I think @gintechsystems might have discovered a great bug! It's certainly feasible (especially if the dex app is running) that the `peripheral.services` array has more than just the service we're interested in.