### PR TITLE
v0.6.0

### DIFF
--- a/Example/xDripG5.xcodeproj/project.pbxproj
+++ b/Example/xDripG5.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		06C991A3D94948120AD2A278 /* Pods_xDripG5_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42011659993839B43D24C553 /* Pods_xDripG5_Example.framework */; };
 		439FCA211C332AA4007DE84C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 439FCA1F1C332AA4007DE84C /* LaunchScreen.storyboard */; };
 		439FCA231C332AE5007DE84C /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439FCA221C332AE5007DE84C /* NSUserDefaults.swift */; };
+		43E3979F1D569B340028E321 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E3979E1D569B340028E321 /* HKUnit.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
@@ -20,6 +21,7 @@
 		42011659993839B43D24C553 /* Pods_xDripG5_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_xDripG5_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		439FCA201C332AA4007DE84C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		439FCA221C332AE5007DE84C /* NSUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUserDefaults.swift; sourceTree = "<group>"; };
+		43E3979E1D569B340028E321 /* HKUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HKUnit.swift; path = ../../xDripG5/HKUnit.swift; sourceTree = "<group>"; };
 		598554A3C216FA3B8F8CD6BE /* xDripG5.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = xDripG5.podspec; path = ../xDripG5.podspec; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* xDripG5_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = xDripG5_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -76,6 +78,7 @@
 			isa = PBXGroup;
 			children = (
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
+				43E3979E1D569B340028E321 /* HKUnit.swift */,
 				439FCA221C332AE5007DE84C /* NSUserDefaults.swift */,
 				607FACD71AFB9204008FA782 /* ViewController.swift */,
 				607FACDC1AFB9204008FA782 /* Assets.xcassets */,
@@ -243,6 +246,7 @@
 			files = (
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
+				43E3979F1D569B340028E321 /* HKUnit.swift in Sources */,
 				439FCA231C332AE5007DE84C /* NSUserDefaults.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/xDripG5/AppDelegate.swift
+++ b/Example/xDripG5/AppDelegate.swift
@@ -25,7 +25,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TransmitterDelegate {
 
         transmitter = Transmitter(
             ID: NSUserDefaults.standardUserDefaults().transmitterID,
-            startTimeInterval: NSUserDefaults.standardUserDefaults().startTimeInterval,
             passiveModeEnabled: NSUserDefaults.standardUserDefaults().passiveModeEnabled
         )
         transmitter?.stayConnected = NSUserDefaults.standardUserDefaults().stayConnected
@@ -81,19 +80,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TransmitterDelegate {
         }
     }
 
-    func transmitter(transmitter: Transmitter, didReadGlucose glucose: GlucoseRxMessage) {
-
-        if let startTime = transmitter.startTimeInterval {
-            NSUserDefaults.standardUserDefaults().startTimeInterval = startTime
-        }
-
+    func transmitter(transmitter: Transmitter, didRead glucose: Glucose) {
         if let vc = window?.rootViewController as? TransmitterDelegate {
             dispatch_async(dispatch_get_main_queue()) {
-                vc.transmitter(transmitter, didReadGlucose: glucose)
+                vc.transmitter(transmitter, didRead: glucose)
             }
         }
     }
 }
-
-
-

--- a/Example/xDripG5/NSUserDefaults.swift
+++ b/Example/xDripG5/NSUserDefaults.swift
@@ -19,21 +19,6 @@ extension NSUserDefaults {
         }
     }
 
-    var startTimeInterval: NSTimeInterval? {
-        get {
-            let value = doubleForKey("startTimeInterval")
-
-            return value > 0 ? value : nil
-        }
-        set {
-            if let value = newValue {
-                setDouble(value, forKey: "startTimeInterval")
-            } else {
-                setObject(nil, forKey: "startTimeInterval")
-            }
-        }
-    }
-
     var stayConnected: Bool {
         get {
             return boolForKey("stayConnected") ?? true

--- a/Example/xDripG5/ViewController.swift
+++ b/Example/xDripG5/ViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import HealthKit
 import xDripG5
 
 class ViewController: UIViewController, TransmitterDelegate, UITextFieldDelegate {
@@ -106,19 +107,18 @@ class ViewController: UIViewController, TransmitterDelegate, UITextFieldDelegate
         subtitleLabel.text = "\(error)"
     }
 
-    func transmitter(transmitter: Transmitter, didReadGlucose glucose: GlucoseRxMessage) {
-        titleLabel.text = NSNumberFormatter.localizedStringFromNumber(NSNumber(short: Int16(glucose.glucose)), numberStyle: .NoStyle)
-
-        if let startTime = transmitter.startTimeInterval {
-            let date = NSDate(timeIntervalSince1970: startTime).dateByAddingTimeInterval(NSTimeInterval(glucose.timestamp))
-
-            subtitleLabel.text = NSDateFormatter.localizedStringFromDate(date, dateStyle: .NoStyle, timeStyle: .LongStyle)
+    func transmitter(transmitter: Transmitter, didRead glucose: Glucose) {
+        let unit = HKUnit.milligramsPerDeciliter()
+        if let value = glucose.glucose?.doubleValueForUnit(unit) {
+            titleLabel.text = "\(value) \(unit.unitString)"
         } else {
-            subtitleLabel.text = "Unknown time"
+            titleLabel.text = String(glucose.state)
         }
 
-    }
 
+        let date = glucose.readDate
+        subtitleLabel.text = NSDateFormatter.localizedStringFromDate(date, dateStyle: .NoStyle, timeStyle: .LongStyle)
+    }
 }
 
 

--- a/xDripG5.podspec
+++ b/xDripG5.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "xDripG5"
-  s.version          = "0.5.0"
+  s.version          = "0.6.0"
   s.summary          = "An interface for communicating with the G5 glucose transmitter over Bluetooth."
 
   s.description      = <<-DESC

--- a/xDripG5.xcodeproj/project.pbxproj
+++ b/xDripG5.xcodeproj/project.pbxproj
@@ -36,6 +36,11 @@
 		43CE7CDC1CA77468003CC1B0 /* TransmitterStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CE7CDB1CA77468003CC1B0 /* TransmitterStatus.swift */; };
 		43DC87C01C8B509B005BC30D /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DC87BF1C8B509B005BC30D /* NSData.swift */; };
 		43DC87C21C8B520F005BC30D /* GlucoseRxMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DC87C11C8B520F005BC30D /* GlucoseRxMessageTests.swift */; };
+		43E3978B1D5668BD0028E321 /* CalibrationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E3978A1D5668BD0028E321 /* CalibrationState.swift */; };
+		43E3978D1D566AEA0028E321 /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43E3978C1D566AEA0028E321 /* HealthKit.framework */; };
+		43E3978F1D566B170028E321 /* Glucose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E3978E1D566B170028E321 /* Glucose.swift */; };
+		43E397911D5692080028E321 /* GlucoseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E397901D5692080028E321 /* GlucoseTests.swift */; };
+		43E397931D56950C0028E321 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E397921D56950C0028E321 /* HKUnit.swift */; };
 		43EEA7111D14DC0800CBBDA0 /* AESCrypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 43EEA70F1D14DC0800CBBDA0 /* AESCrypt.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		43EEA7121D14DC0800CBBDA0 /* AESCrypt.m in Sources */ = {isa = PBXBuildFile; fileRef = 43EEA7101D14DC0800CBBDA0 /* AESCrypt.m */; };
 		43F82BCC1D035AA4006F5DD7 /* TransmitterTimeRxMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F82BCB1D035AA4006F5DD7 /* TransmitterTimeRxMessageTests.swift */; };
@@ -100,6 +105,11 @@
 		43CE7CDB1CA77468003CC1B0 /* TransmitterStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransmitterStatus.swift; sourceTree = "<group>"; };
 		43DC87BF1C8B509B005BC30D /* NSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSData.swift; sourceTree = "<group>"; };
 		43DC87C11C8B520F005BC30D /* GlucoseRxMessageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucoseRxMessageTests.swift; sourceTree = "<group>"; };
+		43E3978A1D5668BD0028E321 /* CalibrationState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalibrationState.swift; sourceTree = "<group>"; };
+		43E3978C1D566AEA0028E321 /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
+		43E3978E1D566B170028E321 /* Glucose.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Glucose.swift; sourceTree = "<group>"; };
+		43E397901D5692080028E321 /* GlucoseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucoseTests.swift; sourceTree = "<group>"; };
+		43E397921D56950C0028E321 /* HKUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HKUnit.swift; sourceTree = "<group>"; };
 		43EEA70F1D14DC0800CBBDA0 /* AESCrypt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AESCrypt.h; sourceTree = "<group>"; };
 		43EEA7101D14DC0800CBBDA0 /* AESCrypt.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AESCrypt.m; sourceTree = "<group>"; };
 		43F82BCB1D035AA4006F5DD7 /* TransmitterTimeRxMessageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransmitterTimeRxMessageTests.swift; sourceTree = "<group>"; };
@@ -114,6 +124,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43E3978D1D566AEA0028E321 /* HealthKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -131,6 +142,7 @@
 		43CABDE91C3506F100005705 = {
 			isa = PBXGroup;
 			children = (
+				43E3978C1D566AEA0028E321 /* HealthKit.framework */,
 				43CABDF51C3506F100005705 /* xDripG5 */,
 				43CABE011C3506F100005705 /* xDripG5Tests */,
 				43CABDF41C3506F100005705 /* Products */,
@@ -149,17 +161,20 @@
 		43CABDF51C3506F100005705 /* xDripG5 */ = {
 			isa = PBXGroup;
 			children = (
-				43CABDF61C3506F100005705 /* xDripG5.h */,
-				43CABDF81C3506F100005705 /* Info.plist */,
+				43EEA70F1D14DC0800CBBDA0 /* AESCrypt.h */,
+				43EEA7101D14DC0800CBBDA0 /* AESCrypt.m */,
 				43CABE0E1C350B2800005705 /* BluetoothManager.swift */,
 				43CABE0F1C350B2800005705 /* BluetoothServices.swift */,
+				43E3978A1D5668BD0028E321 /* CalibrationState.swift */,
+				43E3978E1D566B170028E321 /* Glucose.swift */,
+				43E397921D56950C0028E321 /* HKUnit.swift */,
+				43CABDF81C3506F100005705 /* Info.plist */,
 				43CABE101C350B2800005705 /* NSData.swift */,
 				430D64C41CB7846A00FCA750 /* NSData+CRC.swift */,
 				43CABE111C350B2800005705 /* Transmitter.swift */,
 				43CE7CDB1CA77468003CC1B0 /* TransmitterStatus.swift */,
+				43CABDF61C3506F100005705 /* xDripG5.h */,
 				43CABE161C350B2E00005705 /* Messages */,
-				43EEA70F1D14DC0800CBBDA0 /* AESCrypt.h */,
-				43EEA7101D14DC0800CBBDA0 /* AESCrypt.m */,
 			);
 			path = xDripG5;
 			sourceTree = "<group>";
@@ -167,6 +182,7 @@
 		43CABE011C3506F100005705 /* xDripG5Tests */ = {
 			isa = PBXGroup;
 			children = (
+				43E397901D5692080028E321 /* GlucoseTests.swift */,
 				43DC87C11C8B520F005BC30D /* GlucoseRxMessageTests.swift */,
 				43CABE041C3506F100005705 /* Info.plist */,
 				43DC87BF1C8B509B005BC30D /* NSData.swift */,
@@ -316,6 +332,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				43CE7CCA1CA73B94003CC1B0 /* TransmitterVersionTxMessage.swift in Sources */,
+				43E3978B1D5668BD0028E321 /* CalibrationState.swift in Sources */,
 				43CABE2D1C350B3D00005705 /* TransmitterTimeRxMessage.swift in Sources */,
 				43CABE291C350B3D00005705 /* GlucoseRxMessage.swift in Sources */,
 				43CE7CDC1CA77468003CC1B0 /* TransmitterStatus.swift in Sources */,
@@ -323,6 +340,7 @@
 				43CABE231C350B3D00005705 /* AuthChallengeRxMessage.swift in Sources */,
 				43CABE261C350B3D00005705 /* AuthStatusRxMessage.swift in Sources */,
 				43CE7CD41CA73CE8003CC1B0 /* GlucoseHistoryTxMessage.swift in Sources */,
+				43E397931D56950C0028E321 /* HKUnit.swift in Sources */,
 				43CE7CD01CA73C57003CC1B0 /* SessionStopTxMessage.swift in Sources */,
 				43CABE2A1C350B3D00005705 /* GlucoseTxMessage.swift in Sources */,
 				43CE7CC81CA73AEB003CC1B0 /* FirmwareVersionTxMessage.swift in Sources */,
@@ -332,6 +350,7 @@
 				43CABE2E1C350B3D00005705 /* TransmitterTimeTxMessage.swift in Sources */,
 				43CABE2C1C350B3D00005705 /* TransmitterMessage.swift in Sources */,
 				43CABE131C350B2800005705 /* BluetoothServices.swift in Sources */,
+				43E3978F1D566B170028E321 /* Glucose.swift in Sources */,
 				43CABE151C350B2800005705 /* Transmitter.swift in Sources */,
 				43CABE281C350B3D00005705 /* DisconnectTxMessage.swift in Sources */,
 				43CABE141C350B2800005705 /* NSData.swift in Sources */,
@@ -354,6 +373,7 @@
 				43F82BD41D037227006F5DD7 /* SessionStartRxMessageTests.swift in Sources */,
 				43DC87C01C8B509B005BC30D /* NSData.swift in Sources */,
 				43F82BD21D037040006F5DD7 /* SessionStopRxMessageTests.swift in Sources */,
+				43E397911D5692080028E321 /* GlucoseTests.swift in Sources */,
 				43DC87C21C8B520F005BC30D /* GlucoseRxMessageTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -388,7 +408,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -436,7 +456,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -464,7 +484,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 11;
+				DYLIB_CURRENT_VERSION = 12;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = xDripG5/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -482,7 +502,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 11;
+				DYLIB_CURRENT_VERSION = 12;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = xDripG5/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/xDripG5/CalibrationState.swift
+++ b/xDripG5/CalibrationState.swift
@@ -1,0 +1,58 @@
+//
+//  CalibrationState.swift
+//  xDripG5
+//
+//  Created by Nate Racklyeft on 8/6/16.
+//  Copyright © 2016 Nathan Racklyeft. All rights reserved.
+//
+
+import Foundation
+
+
+public enum CalibrationState {
+    public typealias RawValue = UInt8
+
+    case Stopped
+    case Warmup
+    case NeedFirstInitialCalibration
+    case NeedSecondInitialCalibration
+    case OK
+    case NeedCalibration
+    case Unknown(RawValue)
+
+    init(rawValue: UInt8) {
+        switch rawValue {
+        case 1:
+            self = .Stopped
+        case 2:
+            self = .Warmup
+        case 4:
+            self = .NeedFirstInitialCalibration
+        case 5:
+            self = .NeedSecondInitialCalibration
+        case 6:
+            self = .OK
+        case 7:
+            self = .NeedCalibration
+        default:
+            self = .Unknown(rawValue)
+        }
+    }
+
+    public var hasReliableGlucose: Bool {
+        return self == .OK || self == .NeedCalibration
+    }
+}
+
+extension CalibrationState: Equatable { }
+
+public func ==(lhs: CalibrationState, rhs: CalibrationState) -> Bool {
+    switch (lhs, rhs) {
+    case (.Stopped, .Stopped), (.Warmup, .Warmup), (.NeedFirstInitialCalibration, .NeedFirstInitialCalibration), (.NeedSecondInitialCalibration, .NeedSecondInitialCalibration), (.OK, .OK), (.NeedCalibration, .NeedCalibration):
+        return true
+    case let (.Unknown(lhsRaw), .Unknown(rhsRaw)):
+        return lhsRaw == rhsRaw
+    default:
+        return false
+    }
+}

--- a/xDripG5/Glucose.swift
+++ b/xDripG5/Glucose.swift
@@ -1,0 +1,60 @@
+//
+//  Glucose.swift
+//  xDripG5
+//
+//  Created by Nate Racklyeft on 8/6/16.
+//  Copyright © 2016 Nathan Racklyeft. All rights reserved.
+//
+
+import Foundation
+import HealthKit
+
+
+public struct Glucose {
+    public let glucoseMessage: GlucoseRxMessage
+    let timeMessage: TransmitterTimeRxMessage
+
+    init(glucoseMessage: GlucoseRxMessage, timeMessage: TransmitterTimeRxMessage, activationDate: NSDate) {
+        self.glucoseMessage = glucoseMessage
+        self.timeMessage = timeMessage
+
+        status = TransmitterStatus(rawValue: glucoseMessage.status)
+        state = CalibrationState(rawValue: glucoseMessage.state)
+        sessionStartDate = activationDate.dateByAddingTimeInterval(NSTimeInterval(timeMessage.sessionStartTime))
+        readDate = activationDate.dateByAddingTimeInterval(NSTimeInterval(glucoseMessage.timestamp))
+    }
+
+    // MARK: - Transmitter Info
+    public let status: TransmitterStatus
+    public let sessionStartDate: NSDate
+
+    // MARK: - Glucose Info
+    public let state: CalibrationState
+    public let readDate: NSDate
+
+    public var isDisplayOnly: Bool {
+        return glucoseMessage.glucoseIsDisplayOnly
+    }
+
+    public var glucose: HKQuantity? {
+        guard state.hasReliableGlucose else {
+            return nil
+        }
+
+        let unit = HKUnit.milligramsPerDeciliter()
+
+        return HKQuantity(unit: unit, doubleValue: Double(glucoseMessage.glucose))
+    }
+
+    public var trend: Int {
+        return Int(glucoseMessage.trend)
+    }
+}
+
+
+extension Glucose: Equatable { }
+
+
+public func ==(lhs: Glucose, rhs: Glucose) -> Bool {
+    return lhs.glucoseMessage == rhs.glucoseMessage && lhs.timeMessage == rhs.timeMessage
+}

--- a/xDripG5/HKUnit.swift
+++ b/xDripG5/HKUnit.swift
@@ -1,0 +1,16 @@
+//
+//  HKUnit.swift
+//  xDripG5
+//
+//  Created by Nate Racklyeft on 8/6/16.
+//  Copyright © 2016 Nathan Racklyeft. All rights reserved.
+//
+
+import HealthKit
+
+
+extension HKUnit {
+    static func milligramsPerDeciliter() -> HKUnit {
+        return HKUnit.gramUnitWithMetricPrefix(.Milli).unitDividedByUnit(HKUnit.literUnitWithMetricPrefix(.Deci))
+    }
+}

--- a/xDripG5/Info.plist
+++ b/xDripG5/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.0</string>
+	<string>0.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/xDripG5/Messages/GlucoseRxMessage.swift
+++ b/xDripG5/Messages/GlucoseRxMessage.swift
@@ -11,7 +11,7 @@ import Foundation
 
 public struct GlucoseRxMessage: TransmitterRxMessage {
     static let opcode: UInt8 = 0x31
-    public let status: TransmitterStatus
+    public let status: UInt8
     public let sequence: UInt32
     public let timestamp: UInt32
     public let glucoseIsDisplayOnly: Bool
@@ -22,7 +22,7 @@ public struct GlucoseRxMessage: TransmitterRxMessage {
     init?(data: NSData) {
         if data.length == 16 && data.crcValid() {
             if data[0] == self.dynamicType.opcode {
-                status = TransmitterStatus(rawValue: data[1])
+                status = data[1]
                 sequence = data[2...5]
                 timestamp = data[6...9]
 

--- a/xDripG5/Messages/GlucoseRxMessage.swift
+++ b/xDripG5/Messages/GlucoseRxMessage.swift
@@ -46,5 +46,5 @@ extension GlucoseRxMessage: Equatable {
 }
 
 public func ==(lhs: GlucoseRxMessage, rhs: GlucoseRxMessage) -> Bool {
-    return lhs.sequence == rhs.sequence
+    return lhs.sequence == rhs.sequence && lhs.timestamp == rhs.timestamp
 }

--- a/xDripG5/Messages/SessionStartRxMessage.swift
+++ b/xDripG5/Messages/SessionStartRxMessage.swift
@@ -11,7 +11,7 @@ import Foundation
 
 struct SessionStartRxMessage {
     static let opcode: UInt8 = 0x27
-    let status: TransmitterStatus
+    let status: UInt8
     let received: UInt8
 
     // I've only seen examples of these 2 values matching
@@ -29,7 +29,7 @@ struct SessionStartRxMessage {
             return nil
         }
 
-        status = TransmitterStatus(rawValue: data[1])
+        status = data[1]
         received = data[2]
         requestedStartTime = data[3...6]
         sessionStartTime = data[7...10]

--- a/xDripG5/Messages/SessionStopRxMessage.swift
+++ b/xDripG5/Messages/SessionStopRxMessage.swift
@@ -11,7 +11,7 @@ import Foundation
 
 struct SessionStopRxMessage {
     static let opcode: UInt8 = 0x29
-    let status: TransmitterStatus
+    let status: UInt8
     let received: UInt8
     let sessionStopTime: UInt32
     let sessionStartTime: UInt32
@@ -26,7 +26,7 @@ struct SessionStopRxMessage {
             return nil
         }
 
-        status = TransmitterStatus(rawValue: data[1])
+        status = data[1]
         received = data[2]
         sessionStopTime = data[3...6]
         sessionStartTime = data[7...10]

--- a/xDripG5/Messages/TransmitterTimeRxMessage.swift
+++ b/xDripG5/Messages/TransmitterTimeRxMessage.swift
@@ -11,7 +11,7 @@ import Foundation
 
 struct TransmitterTimeRxMessage: TransmitterRxMessage {
     static let opcode: UInt8 = 0x25
-    let status: TransmitterStatus
+    let status: UInt8
     let currentTime: UInt32
     let sessionStartTime: UInt32
 
@@ -24,8 +24,14 @@ struct TransmitterTimeRxMessage: TransmitterRxMessage {
             return nil
         }
 
-        status = TransmitterStatus(rawValue: data[1])
+        status = data[1]
         currentTime = data[2...5]
         sessionStartTime = data[6...9]
     }
+}
+
+extension TransmitterTimeRxMessage: Equatable { }
+
+func ==(lhs: TransmitterTimeRxMessage, rhs: TransmitterTimeRxMessage) -> Bool {
+    return lhs.currentTime == rhs.currentTime
 }

--- a/xDripG5/TransmitterStatus.swift
+++ b/xDripG5/TransmitterStatus.swift
@@ -10,11 +10,13 @@ import Foundation
 
 
 public enum TransmitterStatus {
+    public typealias RawValue = UInt8
+
     case OK
     case LowBattery
-    case Unknown(UInt8)
+    case Unknown(RawValue)
 
-    init(rawValue: UInt8) {
+    init(rawValue: RawValue) {
         switch rawValue {
         case 0:
             self = .OK

--- a/xDripG5/TransmitterStatus.swift
+++ b/xDripG5/TransmitterStatus.swift
@@ -19,9 +19,9 @@ public enum TransmitterStatus {
         case 0:
             self = .OK
         case 0x81:
-            self = LowBattery
+            self = .LowBattery
         default:
-            self = Unknown(rawValue)
+            self = .Unknown(rawValue)
         }
     }
 }

--- a/xDripG5Tests/GlucoseRxMessageTests.swift
+++ b/xDripG5Tests/GlucoseRxMessageTests.swift
@@ -16,7 +16,7 @@ class GlucoseRxMessageTests: XCTestCase {
         let data = NSData(hexadecimalString: "3100680a00008a715700cc0006ffc42a")!
         let message = GlucoseRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(2664, message.sequence)
         XCTAssertEqual(5730698, message.timestamp)
         XCTAssertFalse(message.glucoseIsDisplayOnly)
@@ -29,7 +29,7 @@ class GlucoseRxMessageTests: XCTestCase {
         let data = NSData(hexadecimalString: "31006f0a0000be7957007a0006e4818d")!
         let message = GlucoseRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(2671, message.sequence)
         XCTAssertEqual(5732798, message.timestamp)
         XCTAssertFalse(message.glucoseIsDisplayOnly)
@@ -42,7 +42,7 @@ class GlucoseRxMessageTests: XCTestCase {
         let data = NSData(hexadecimalString: "3100700a0000f17a5700584006e3cee9")!
         let message = GlucoseRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(2672, message.sequence)
         XCTAssertEqual(5733105, message.timestamp)
         XCTAssertTrue(message.glucoseIsDisplayOnly)
@@ -55,7 +55,7 @@ class GlucoseRxMessageTests: XCTestCase {
         let data = NSData(hexadecimalString: "3100aa00000095a078008b00060a8b34")!
         let message = GlucoseRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(170, message.sequence)
         XCTAssertEqual(7905429, message.timestamp)  // 90 days, status is still OK
         XCTAssertFalse(message.glucoseIsDisplayOnly)

--- a/xDripG5Tests/GlucoseRxMessageTests.swift
+++ b/xDripG5Tests/GlucoseRxMessageTests.swift
@@ -50,5 +50,18 @@ class GlucoseRxMessageTests: XCTestCase {
         XCTAssertEqual(6, message.state)
         XCTAssertEqual(-29, message.trend)
     }
-    
+
+    func testOldTransmitter() {
+        let data = NSData(hexadecimalString: "3100aa00000095a078008b00060a8b34")!
+        let message = GlucoseRxMessage(data: data)!
+
+        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(170, message.sequence)
+        XCTAssertEqual(7905429, message.timestamp)  // 90 days, status is still OK
+        XCTAssertFalse(message.glucoseIsDisplayOnly)
+        XCTAssertEqual(139, message.glucose)
+        XCTAssertEqual(6, message.state)
+        XCTAssertEqual(10, message.trend)
+    }
+
 }

--- a/xDripG5Tests/GlucoseTests.swift
+++ b/xDripG5Tests/GlucoseTests.swift
@@ -1,0 +1,82 @@
+//
+//  GlucoseTests.swift
+//  xDripG5
+//
+//  Created by Nate Racklyeft on 8/6/16.
+//  Copyright © 2016 Nathan Racklyeft. All rights reserved.
+//
+
+import XCTest
+import HealthKit
+@testable import xDripG5
+
+class GlucoseTests: XCTestCase {
+
+    var timeMessage: TransmitterTimeRxMessage!
+    let calendar = NSCalendar(identifier: NSCalendarIdentifierGregorian)
+    var activationDate: NSDate!
+
+    override func setUp() {
+        super.setUp()
+
+        let data = NSData(hexadecimalString: "2500470272007cff710001000000fa1d")!
+        timeMessage = TransmitterTimeRxMessage(data: data)!
+
+        calendar?.timeZone = NSTimeZone(name: "UTC")!
+        activationDate = calendar?.dateWithEra(1, year: 2016, month: 10, day: 1, hour: 0, minute: 0, second: 0, nanosecond: 0)!
+    }
+
+    func testMessageData() {
+        let data = NSData(hexadecimalString: "3100680a00008a715700cc0006ffc42a")!
+        let message = GlucoseRxMessage(data: data)!
+        let glucose = Glucose(glucoseMessage: message, timeMessage: timeMessage, activationDate: activationDate)
+
+        XCTAssertEqual(TransmitterStatus.OK, glucose.status)
+        XCTAssertEqual(calendar?.dateWithEra(1, year: 2016, month: 12, day: 6, hour: 7, minute: 51, second: 38, nanosecond: 0)!, glucose.readDate)
+        XCTAssertEqual(calendar?.dateWithEra(1, year: 2016, month: 12, day: 26, hour: 11, minute: 16, second: 12, nanosecond: 0)!, glucose.sessionStartDate)
+        XCTAssertFalse(glucose.isDisplayOnly)
+        XCTAssertEqual(204, glucose.glucose?.doubleValueForUnit(HKUnit.milligramsPerDeciliter()))
+        XCTAssertEqual(CalibrationState.OK, glucose.state)
+        XCTAssertEqual(-1, glucose.trend)
+    }
+
+    func testNegativeTrend() {
+        let data = NSData(hexadecimalString: "31006f0a0000be7957007a0006e4818d")!
+        let message = GlucoseRxMessage(data: data)!
+        let glucose = Glucose(glucoseMessage: message, timeMessage: timeMessage, activationDate: activationDate)
+
+        XCTAssertEqual(TransmitterStatus.OK, glucose.status)
+        XCTAssertEqual(calendar?.dateWithEra(1, year: 2016, month: 12, day: 6, hour: 8, minute: 26, second: 38, nanosecond: 0)!, glucose.readDate)
+        XCTAssertFalse(glucose.isDisplayOnly)
+        XCTAssertEqual(122, glucose.glucose?.doubleValueForUnit(HKUnit.milligramsPerDeciliter()))
+        XCTAssertEqual(CalibrationState.OK, glucose.state)
+        XCTAssertEqual(-28, glucose.trend)
+    }
+
+    func testDisplayOnly() {
+        let data = NSData(hexadecimalString: "3100700a0000f17a5700584006e3cee9")!
+        let message = GlucoseRxMessage(data: data)!
+        let glucose = Glucose(glucoseMessage: message, timeMessage: timeMessage, activationDate: activationDate)
+
+        XCTAssertEqual(TransmitterStatus.OK, glucose.status)
+        XCTAssertEqual(calendar?.dateWithEra(1, year: 2016, month: 12, day: 6, hour: 8, minute: 31, second: 45, nanosecond: 0)!, glucose.readDate)
+        XCTAssertTrue(glucose.isDisplayOnly)
+        XCTAssertEqual(88, glucose.glucose?.doubleValueForUnit(HKUnit.milligramsPerDeciliter()))
+        XCTAssertEqual(CalibrationState.OK, glucose.state)
+        XCTAssertEqual(-29, message.trend)
+    }
+
+    func testOldTransmitter() {
+        let data = NSData(hexadecimalString: "3100aa00000095a078008b00060a8b34")!
+        let message = GlucoseRxMessage(data: data)!
+        let glucose = Glucose(glucoseMessage: message, timeMessage: timeMessage, activationDate: activationDate)
+
+        XCTAssertEqual(TransmitterStatus.OK, glucose.status)
+        XCTAssertEqual(calendar?.dateWithEra(1, year: 2016, month: 12, day: 31, hour: 11, minute: 57, second: 09, nanosecond: 0)!, glucose.readDate)  // 90 days, status is still OK
+        XCTAssertFalse(glucose.isDisplayOnly)
+        XCTAssertEqual(139, glucose.glucose?.doubleValueForUnit(HKUnit.milligramsPerDeciliter()))
+        XCTAssertEqual(CalibrationState.OK, glucose.state)
+        XCTAssertEqual(10, message.trend)
+    }
+    
+}

--- a/xDripG5Tests/Info.plist
+++ b/xDripG5Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.0</string>
+	<string>0.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/xDripG5Tests/SessionStartRxMessageTests.swift
+++ b/xDripG5Tests/SessionStartRxMessageTests.swift
@@ -16,7 +16,7 @@ class SessionStartRxMessageTests: XCTestCase {
         var data = NSData(hexadecimalString: "2700014bf871004bf87100e9f8710095d9")!
         var message = SessionStartRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(1, message.received)
         XCTAssertEqual(7469131, message.requestedStartTime)
         XCTAssertEqual(7469131, message.sessionStartTime)
@@ -25,7 +25,7 @@ class SessionStartRxMessageTests: XCTestCase {
         data = NSData(hexadecimalString: "2700012bfd71002bfd710096fd71000f6a")!
         message = SessionStartRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(1, message.received)
         XCTAssertEqual(7470379, message.requestedStartTime)
         XCTAssertEqual(7470379, message.sessionStartTime)
@@ -34,7 +34,7 @@ class SessionStartRxMessageTests: XCTestCase {
         data = NSData(hexadecimalString: "2700017cff71007cff7100eeff7100aeed")!
         message = SessionStartRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(1, message.received)
         XCTAssertEqual(7470972, message.requestedStartTime)
         XCTAssertEqual(7470972, message.sessionStartTime)

--- a/xDripG5Tests/SessionStopRxMessageTests.swift
+++ b/xDripG5Tests/SessionStopRxMessageTests.swift
@@ -16,7 +16,7 @@ class SessionStopRxMessageTests: XCTestCase {
         var data = NSData(hexadecimalString: "29000128027200ffffffff47027200ba85")!
         var message = SessionStopRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(1, message.received)
         XCTAssertEqual(7471656, message.sessionStopTime)
         XCTAssertEqual(0xffffffff, message.sessionStartTime)
@@ -25,7 +25,7 @@ class SessionStopRxMessageTests: XCTestCase {
         data = NSData(hexadecimalString: "2900013ffe7100ffffffffc2fe71008268")!
         message = SessionStopRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(1, message.received)
         XCTAssertEqual(7470655, message.sessionStopTime)
         XCTAssertEqual(0xffffffff, message.sessionStartTime)
@@ -34,7 +34,7 @@ class SessionStopRxMessageTests: XCTestCase {
         data = NSData(hexadecimalString: "290001f5fb7100ffffffff6afc7100fa8a")!
         message = SessionStopRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(1, message.received)
         XCTAssertEqual(7470069, message.sessionStopTime)
         XCTAssertEqual(0xffffffff, message.sessionStartTime)

--- a/xDripG5Tests/TransmitterTimeRxMessageTests.swift
+++ b/xDripG5Tests/TransmitterTimeRxMessageTests.swift
@@ -16,21 +16,21 @@ class TransmitterTimeRxMessageTests: XCTestCase {
         var data = NSData(hexadecimalString: "2500e8f87100ffffffff010000000a70")!
         var message = TransmitterTimeRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(7469288, message.currentTime)
         XCTAssertEqual(0xffffffff, message.sessionStartTime)
 
         data = NSData(hexadecimalString: "250096fd7100ffffffff01000000226d")!
         message = TransmitterTimeRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(7470486, message.currentTime)
         XCTAssertEqual(0xffffffff, message.sessionStartTime)
 
         data = NSData(hexadecimalString: "2500eeff7100ffffffff010000008952")!
         message = TransmitterTimeRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(7471086, message.currentTime)
         XCTAssertEqual(0xffffffff, message.sessionStartTime)
     }
@@ -39,7 +39,7 @@ class TransmitterTimeRxMessageTests: XCTestCase {
         let data = NSData(hexadecimalString: "2500470272007cff710001000000fa1d")!
         let message = TransmitterTimeRxMessage(data: data)!
 
-        XCTAssertEqual(TransmitterStatus.OK, message.status)
+        XCTAssertEqual(0, message.status)
         XCTAssertEqual(7471687, message.currentTime)
         XCTAssertEqual(7470972, message.sessionStartTime)
 


### PR DESCRIPTION
* Updating the `delegate` API to return a new, higher-level `Glucose` object
* Surfacing `Transmitter` `activationDate` and `sessionStartDate`
* Simplifying the `Transmitter` initializer