### PR TITLE
Delay control subscription until after auth

### DIFF
--- a/CGMBLEKit/BluetoothManager.swift
+++ b/CGMBLEKit/BluetoothManager.swift
@@ -45,6 +45,13 @@ protocol BluetoothManagerDelegate: class {
     ///   - manager: The bluetooth manager
     ///   - response: The data received on the backfill characteristic
     func bluetoothManager(_ manager: BluetoothManager, didReceiveBackfillResponse response: Data)
+
+    /// Informs the delegate that the bluetooth manager received new data in the authentication characteristic
+    ///
+    /// - Parameters:
+    ///   - manager: The bluetooth manager
+    ///   - response: The data received on the authentication characteristic
+    func bluetoothManager(_ manager: BluetoothManager, peripheralManager: PeripheralManager, didReceiveAuthenticationResponse response: Data)
 }
 
 
@@ -320,12 +327,14 @@ extension BluetoothManager: PeripheralManagerDelegate {
         }
 
         switch CGMServiceCharacteristicUUID(rawValue: characteristic.uuid.uuidString.uppercased()) {
-        case .none, .communication?, .authentication?:
+        case .none, .communication?:
             return
         case .control?:
             self.delegate?.bluetoothManager(self, didReceiveControlResponse: value)
         case .backfill?:
             self.delegate?.bluetoothManager(self, didReceiveBackfillResponse: value)
+        case .authentication?:
+            self.delegate?.bluetoothManager(self, peripheralManager: manager, didReceiveAuthenticationResponse: value)
         }
     }
 }

--- a/CGMBLEKit/BluetoothServices.swift
+++ b/CGMBLEKit/BluetoothServices.swift
@@ -40,15 +40,24 @@ enum DeviceInfoCharacteristicUUID: String, CBUUIDRawValue {
 
 
 enum CGMServiceCharacteristicUUID: String, CBUUIDRawValue {
+
     // Read/Notify
     case communication = "F8083533-849E-531C-C594-30F1F86A4EA5"
+
     // Write/Indicate
     case control = "F8083534-849E-531C-C594-30F1F86A4EA5"
-    // Read/Write/Indicate
+
+    // Write/Indicate
     case authentication = "F8083535-849E-531C-C594-30F1F86A4EA5"
 
     // Read/Write/Notify
     case backfill = "F8083536-849E-531C-C594-30F1F86A4EA5"
+
+//    // Unknown attribute present on older G6 transmitters
+//    case unknown1 = "F8083537-849E-531C-C594-30F1F86A4EA5"
+//
+//    // Updated G6 characteristic (read/notify)
+//    case unknown2 = "F8083538-849E-531C-C594-30F1F86A4EA5"
 }
 
 

--- a/CGMBLEKit/Messages/AuthChallengeRxMessage.swift
+++ b/CGMBLEKit/Messages/AuthChallengeRxMessage.swift
@@ -10,8 +10,8 @@ import Foundation
 
 
 struct AuthChallengeRxMessage: TransmitterRxMessage {
-    let authenticated: UInt8
-    let bonded: UInt8
+    let isAuthenticated: Bool
+    let isBonded: Bool
 
     init?(data: Data) {
         guard data.count >= 3 else {
@@ -22,7 +22,7 @@ struct AuthChallengeRxMessage: TransmitterRxMessage {
             return nil
         }
 
-        authenticated = data[1]
-        bonded = data[2]
+        isAuthenticated = data[1] == 0x1
+        isBonded = data[2] == 0x1
     }
 }


### PR DESCRIPTION
Fixes issues seen with new G6 transmitters.  Also allows Dexcom app to pair while CGMBLEKit (or Loop) is running in passive mode against the same transmitter.