### PR TITLE
Filter out future-dated sensor events

### DIFF
--- a/CGMBLEKit/TransmitterManager.swift
+++ b/CGMBLEKit/TransmitterManager.swift
@@ -336,10 +336,15 @@ public class TransmitterManager: TransmitterDelegate {
         }
 
         // Filter out future-dated events
+        // Stopgap measure for the issue described in https://github.com/LoopKit/Loop/issues/2087
         events = events.filter { event in
-            return event.date <= Date() // Ensure event date is not in the future
+            if event.date > Date() {
+                log.error("Future-dated event detected: %{public}@", String(describing: event))
+                return false
+            }
+            return true
         }
-        
+
         if !events.isEmpty {
             shareManager.delegate.notify { delegate in
                 delegate?.cgmManager(self.shareManager, hasNew: events)

--- a/CGMBLEKit/TransmitterManager.swift
+++ b/CGMBLEKit/TransmitterManager.swift
@@ -335,6 +335,11 @@ public class TransmitterManager: TransmitterDelegate {
             ))
         }
 
+        // Filter out future-dated events
+        events = events.filter { event in
+            return event.date <= Date() // Ensure event date is not in the future
+        }
+        
         if !events.isEmpty {
             shareManager.delegate.notify { delegate in
                 delegate?.cgmManager(self.shareManager, hasNew: events)


### PR DESCRIPTION
Implemented a filter in TransmitterManager to exclude future-dated sensor events before sending to Nightscout. The solution has been successfully tested with a real sensor.

Resolves https://github.com/LoopKit/Loop/issues/2087
