### PR TITLE
add link for G6 URL

### DIFF
--- a/CGMBLEKit/TransmitterManager.swift
+++ b/CGMBLEKit/TransmitterManager.swift
@@ -473,7 +473,7 @@ public class G6CGMManager: TransmitterManager, CGMManager {
     public let isOnboarded = true   // No distinction between created and onboarded
 
     public var appURL: URL? {
-        return nil
+        return URL(string: "dexcomg6://")
     }
 
     public override var device: HKDevice? {


### PR DESCRIPTION
Add link to G6, instead of returning nil. Request from Trio team.