### PR TITLE
return nil for URL in Transmitter Manager

### DIFF
--- a/CGMBLEKit/TransmitterManager.swift
+++ b/CGMBLEKit/TransmitterManager.swift
@@ -446,7 +446,7 @@ public class G5CGMManager: TransmitterManager, CGMManager {
     public let isOnboarded = true   // No distinction between created and onboarded
 
     public var appURL: URL? {
-        return URL(string: "dexcomcgm://")
+        return nil
     }
 
     public override var device: HKDevice? {
@@ -483,12 +483,12 @@ public class G6CGMManager: TransmitterManager, CGMManager {
     public let isOnboarded = true   // No distinction between created and onboarded
 
     public var appURL: URL? {
-        return URL(string: "dexcomg6://")
+        return nil
     }
 
     public override var device: HKDevice? {
         return HKDevice(
-            name: "CGMBLEKit",
+            name: transmitter.ID,
             manufacturer: "Dexcom",
             model: "G6",
             hardwareVersion: nil,


### PR DESCRIPTION
## Purpose

The behavior for G5 and G7 does not match that for G6 in that G5 and G7 open the CGMManager screen for G5 and G7, from which user can progress to the Dexcom app by selecting `Open App` row. (See note below about G5).

See also: https://github.com/LoopKit/Loop/pull/2353

## Method

* I modified the GxCGMManger to return nil for the appURL.
* I also made the G6CGMManager more similar to the G5CGMManager in using transmitter.ID instead of the hardcoded string

### Details

I looked for differences in how G5, G6 and G7 were handled
* G7CGMManager explicitly returns nil for appURL
* CGMBLEKit has 2 managers
   * class G6CGMManager returns URL(string: "dexcomcgm://") for appURL
   * class G6CGMManager returns URL(string: "dexcomg6://") for appURL

I suspect the behavior difference between G5 and G6 as seen in [this test](https://github.com/LoopKit/Loop/pull/2353#issuecomment-3316073859) on my test phone is that I have a Dexcom G6 loaded on the test phone whereas I do not have a Dexcom G5 app on the test phone.

So long as a valid appURL is returned at the top level, then the main Loop app will go to that URL when the glucose field is tapped on the main Loop screen.

If a valid appURL is not returned at the top level, then the main Loop app goes to the Loop CGM screen from which the appURL is reached via the `Open App` row.

## Test

These tests were done with Loop using the dev branch. This test phone does not have a G5 app, but does have a G6 and a G7 app.

| CGM | dev Action | PR Action |
|:--|:-:|:-:|
| G5 |  CGMManager G5 screen | CGMManager G5 screen |
| G6 | Dexcom app | CGMManager G6 Screen |
| G7 | CGMManager G7 Screen | CGMManager G7 Screen |
| Libre | n/a | n/a |
| Nightscout | NS URL | NS URL |
