### PR TITLE
Translations, localizable.xcstrings (Multilingual)

### DIFF
--- a/CGMBLEKit/CGMBLEKitUI/mul.lproj/TransmitterManagerSetup.xcstrings
+++ b/CGMBLEKit/CGMBLEKitUI/mul.lproj/TransmitterManagerSetup.xcstrings
@@ -1,0 +1,1158 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "5oU-vK-JHQ.text" : {
+      "comment" : "Class = \"UILabel\"; text = \"Credentials\"; ObjectID = \"5oU-vK-JHQ\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بيانات التسجيل"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Legitimationsoplysninger"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Logindaten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Credentials"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credenciales"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tunnukset"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Identifiant"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Credentials"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Credentials"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credenziali"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Påloggingsinformasjon"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toegangsgegevens"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dane uwierzytelniające"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Credentials"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credenciais"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Учетные данные"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poverenia"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inloggningsuppgifter"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kimlik bilgileri"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Облікові дані"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thông tin xác thực"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Credentials"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密钥"
+          }
+        }
+      }
+    },
+    "Dds-49-o7G.title" : {
+      "comment" : "Class = \"UITableViewController\"; title = \"Transmitter Setup\"; ObjectID = \"Dds-49-o7G\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إعداد جهاز الإرسال"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Senderopsætning"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transmitter-Setup"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter Setup"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuración del transmisor"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lähettimen asennus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuration du transmetteur"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter Setup"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter Setup"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurazione trasmettitore"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sett opp sender"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zender instellen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfiguracja nadajnika"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter Setup"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuração do Transmissor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройка трансмиттера"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nastavenie vysielača"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sändarinställningar"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verici Kurulumu"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Налаштування Трасмітера"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cài đặt Transmitter"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter Setup"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置发射器"
+          }
+        }
+      }
+    },
+    "GOT-KQ-cEh.text" : {
+      "comment" : "Class = \"UILabel\"; text = \"Detail\"; ObjectID = \"GOT-KQ-cEh\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تفاصيل"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalje"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detail"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Detail"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalle"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Detail"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Détail"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Detail"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Detail"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dettaglio"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalj"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detail"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Detail"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Detail"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Detail"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подробности"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podrobnosti"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalj"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detay"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Детальніше"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chi tiết"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Detail"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "详情"
+          }
+        }
+      }
+    },
+    "k1N-Rg-XDy.footerTitle" : {
+      "comment" : "Class = \"UITableViewSection\"; footerTitle = \"Data can be downloaded over the Internet from Share when the transmitter connection fails.\"; ObjectID = \"k1N-Rg-XDy\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمكن تحميل البيانات عبر الإنترنت من تطبيق Share عند فشل اتصال المرسل."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data kan downloades via internet fra Share, hvis senderforbindelsen mislykkes."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daten können über das Internet von Share heruntergeladen werden, wenn die Verbindung zum Transmitter unterbrochen ist."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Data can be downloaded over the Internet from Share when the transmitter connection fails."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los datos pueden descargarse, vía internet, desde el Share cuando la conexión del transmisor falla."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiedot voidaan ladata Internetistä Share-palvelimelta, kun yhteys lähettimeen epäonnistuu."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les données peuvent être téléchargées depuis Internet avec Share quand la connexion au transmetteur échoue."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Data can be downloaded over the Internet from Share when the transmitter connection fails."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Data can be downloaded over the Internet from Share when the transmitter connection fails."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In caso di problemi di connessione del trasmettitore, puoi scaricare i dati da Internet grazie alla funzionalità Share."
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data kan lastes ned over internett fra Share-server om tilkobling til sender ikke fungerer."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gegevens kunnen via het internet van Share gedownload worden wanneer de verbinding met de zender uitvalt."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dane można pobrać przez internet z Share, kiedy połączenie nadajnika się nie powiedzie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Data can be downloaded over the Internet from Share when the transmitter connection fails."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os dados podem ser baixados pela Internet a partir do compartilhamento quando a conexão do transmissor falhar."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Данные могут быть загружены с серверов Share если не произойдет соединение трансмиттера."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Údaje je možné stiahnuť cez internet zo Share, keď zlyhá pripojenie vysielača."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data kan laddas ned från Dexcom Share (via Internet) om sändaranslutningen skulle misslyckas."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verici bağlantısı başarısız olduğunda Dexcom Share üzerinden  veriler indirilebilir."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дані можуть бути завантажені по мережі через Sharе, у разі помилки зʼєднання трансмітера."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dữ liệu có thể được tải xuống qua Internet từ Chia sẻ khi kết nối bộ phát không thành công."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Data can be downloaded over the Internet from Share when the transmitter connection fails."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当无法连接发射器时,可通过网络从Dexcom远程下载数据"
+          }
+        }
+      }
+    },
+    "k1N-Rg-XDy.headerTitle" : {
+      "comment" : "Class = \"UITableViewSection\"; headerTitle = \"Dexcom Share\"; ObjectID = \"k1N-Rg-XDy\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ديكسكوم شير"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom Share"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom Share"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dexcom Share"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom Share"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dexcom Share"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom Share"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dexcom Share"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dexcom Share"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom Share"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom Share"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom Share"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dexcom Share"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dexcom Share"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dexcom Share"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom Share"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom Share"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom Share"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom Share"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom Share"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dữ liệu từ Dexcom Share"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dexcom Share"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom远程"
+          }
+        }
+      }
+    },
+    "nKX-TW-GhD.placeholder" : {
+      "comment" : "Class = \"UITextField\"; placeholder = \"Enter the 6-digit transmitter ID\"; ObjectID = \"nKX-TW-GhD\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أدخل معرف جهاز الإرسال المكون من 6 أرقام"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Angiv det 6-cifrede sender-ID"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geben Sie die 6-stellige Transmitter-ID ein"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter the 6-digit transmitter ID"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduzca la identificación de 6 cifras del transmisor"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syötä 6-numeroinen lähettimen tunniste"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrez l’ID du transmetteur, composé de 6 lettres et chiffres"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter the 6-digit transmitter ID"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter the 6-digit transmitter ID"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inserisci ID a 6 cifre del trasmettitore"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skriv 6-siffret sender ID"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vul het 6 cijferige serienummer van de zender in"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wprowadź 6-cyfrowy ID nadajnika"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter the 6-digit transmitter ID"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digite o ID do transmissor de 6 dígitos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите шестизначный идентификатор трансмиттера"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zadajte 6-miestne ID vysielača"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ange 6-siffrigt sändar-ID"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6 basamaklı verici kimliğini girin"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введіть 6-значний ID трансмітера"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nhập 6 số ID của Transmitter"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enter the 6-digit transmitter ID"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请输入6位发射器编号"
+          }
+        }
+      }
+    },
+    "Qub-6B-0aB.footerTitle" : {
+      "comment" : "Class = \"UITableViewSection\"; footerTitle = \"The transmitter ID can be found printed on the back of the device, on the side of the box it came in, and from within the settings menus of the receiver and mobile app.\"; ObjectID = \"Qub-6B-0aB\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يمكن العثور على معرف جهاز الإرسال مطبوعا على الجزء الخلفي من الجهاز، على جانب الصندوق الذي أتى به، ومن داخل قوائم الإعدادات الخاصة بالمستلم والتطبيق الموبايل."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sender-ID'et kan findes trykt på bagsiden af ​​enheden, på siden af æsken, den kom i, og via indstillingsmenuerne på modtageren og mobil-appen."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Transmitter-ID befindet sich auf der Rückseite des Transmitters, an der Seite der Verpackung und in den Einstellungsmenüs des Empfängers sowie der Dexcom-App."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The transmitter ID can be found printed on the back of the device, on the side of the box it came in, and from within the settings menus of the receiver and mobile app."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La identificación del transmisor puede encontrarse en la parte trasera del dispositivo, en el lateral de la caja en la que venía, o en los menús de ajustes del receptor y la app del teléfono móvil. "
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lähettimen tunniste on painettu lähettimen pohjaan ja tuotepakkauksen sivulle. Se löytyy myös vastaanottimen ja mobiilisovelluksen asetusvalikosta."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’ID du transmetteur se trouve sur le dos de l’appareil, sur la boîte dans laquelle il est fourni, et depuis les menus de réglages du récepteur et de l’application mobile."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The transmitter ID can be found printed on the back of the device, on the side of the box it came in, and from within the settings menus of the receiver and mobile app."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The transmitter ID can be found printed on the back of the device, on the side of the box it came in, and from within the settings menus of the receiver and mobile app."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'ID del trasmettitore è riportato sul retro del dispositivo, ai lati della confezione di imballaggio e nel menù impostazioni del ricevitore dell’app per dispositivi mobili."
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sender ID finner du på baksiden av senderen, eller på siden av esken den kom i, eller under innstillinger i appen til senderen."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Het serienummer van de zender staat achter op het apparaat, op de zijkant van de verpakking en in het instellingenmenu van de ontvanger en de app."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID nadajnika jest nadrukowany z tyłu urządzenia, z boku opakowania, w którym go dostarczono oraz jest dostępny w menu ustawień odbiornika i w aplikacji mobilnej."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The transmitter ID can be found printed on the back of the device, on the side of the box it came in, and from within the settings menus of the receiver and mobile app."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O ID do transmissor pode ser encontrado impresso na parte traseira do dispositivo, na parte lateral da caixa em que ele veio e nos menus de configurações do receptor e do aplicativo móvel."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Номер трансмиттера находится на обратной стороне устройства, сбоку кпаковочной коробки, в настройках ресивера и мобильного приложения."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID vysielača nájdete vytlačené na zadnej strane zariadenia, na boku škatule, v ktorej bol dodaný, a v ponuke nastavení prijímača a mobilnej aplikácie."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sändar-ID kan hittas tryckt på baksidan av enheten, på sidan av lådan den kom i, samt från inställningsmenyn för mottagaren och mobilappen."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verici kimliğini, cihazın arkasında, geldiği kutunun yan tarafında, alıcının mobil uygulamasının ayarlar menüsünde bulabilirsiniz."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID Трансмітера вказано на зворотній стороні девайса, на бічній стороні упаковки, а також в меню налаштувань ресивера та мобільного додатку."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Số ID của Transmitter có thể được tìm thấy trên vỏ hộp hoặc bên hông hộp và trong phần Menu cài đặt cũng như trên ứng dụng của điện thoại."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The transmitter ID can be found printed on the back of the device, on the side of the box it came in, and from within the settings menus of the receiver and mobile app."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发射器编号可在发射器包装盒背面找到，或者可在Dexcom Moblie软件及接受器的“setting”-“Transmitter”中找到"
+          }
+        }
+      }
+    },
+    "Qub-6B-0aB.headerTitle" : {
+      "comment" : "Class = \"UITableViewSection\"; headerTitle = \"Transmitter ID\"; ObjectID = \"Qub-6B-0aB\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "معرف المرسل"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sender ID"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sender-ID"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter ID"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID del transmisor"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter ID"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID du transmetteur"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter ID"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeladó ID"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID trasmettitore"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sender-ID"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zender ID"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter ID"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID do transmissor"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID do transmissor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID трансмиттера"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID vysielača"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sändar-ID"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verici ID"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID передавача"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Số ID của Transmitter"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter ID"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发射器编号"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/CGMBLEKit/Localizable.xcstrings
+++ b/CGMBLEKit/Localizable.xcstrings
@@ -4,6 +4,12 @@
     "Dexcom G5" : {
       "comment" : "CGM display title",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ديكسكوم G5"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24,7 +30,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Dexcom G5"
           }
         },
@@ -36,7 +42,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Dexcom G5"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Dexcom G5"
           }
         },
@@ -46,13 +58,7 @@
             "value" : "Dexcom G5"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dexcom G5"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dexcom G5"
@@ -66,19 +72,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Dexcom G5"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Dexcom G5"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dexcom G5"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Dexcom G5"
           }
         },
@@ -106,10 +112,28 @@
             "value" : "Dexcom G5"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom G5"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dexcom G5"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dexcom G5"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom G 5"
           }
         }
       }
@@ -117,6 +141,12 @@
     "Dexcom G6" : {
       "comment" : "CGM display title",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ديكسكوم G6"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -137,7 +167,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Dexcom G6"
           }
         },
@@ -149,7 +179,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Dexcom G6"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Dexcom G6"
           }
         },
@@ -159,13 +195,7 @@
             "value" : "Dexcom G6"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dexcom G6"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dexcom G6"
@@ -179,19 +209,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Dexcom G6"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Dexcom G6"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dexcom G6"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Dexcom G6"
           }
         },
@@ -219,10 +249,28 @@
             "value" : "Dexcom G6"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dexcom G6"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dexcom G6"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dexcom G6"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "德康 G6"
           }
         }
       }
@@ -230,34 +278,34 @@
     "Glucose data is unavailable" : {
       "comment" : "Error description for unreliable state",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Údaje o glukóze nejsou k dispozici"
+            "value" : "قراءات السكر غير متوفرة"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Glukosedata ikke tilgængeligt"
+            "value" : "Glukosedata er utilgængelig"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Blutzuckerdaten sind nicht verfügbar"
+            "value" : "Glukosewerte sind nicht verfügbar"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Los datos de glucosa no están disponibles"
+            "value" : "Datos de glucosa no disponibles"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Glukoositietoja ei ole saatavilla"
+            "state" : "new",
+            "value" : "Glucose data is unavailable"
           }
         },
         "fr" : {
@@ -268,14 +316,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מידע גלוקוז לא זמין"
+            "state" : "new",
+            "value" : "Glucose data is unavailable"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ग्लूकोस डेटा उपलब्ध नहीं है"
+            "state" : "new",
+            "value" : "Glucose data is unavailable"
           }
         },
         "it" : {
@@ -284,13 +332,7 @@
             "value" : "I dati della glicemia non sono disponibili"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "グルコースデータがありません"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Blodsukker er utilgjengelig"
@@ -299,25 +341,25 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Glucosegegevens zijn niet beschikbaar"
+            "value" : "Glucose gegevens niet beschikbaar"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dane o poziomie glukozy są niedostępne"
+            "state" : "new",
+            "value" : "Glucose data is unavailable"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose data is unavailable"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Os dados de glicose não estão disponíveis"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datele despre glucoză nu sunt disponibile"
+            "state" : "new",
+            "value" : "Glucose data is unavailable"
           }
         },
         "ru" : {
@@ -329,31 +371,43 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Údaje o glykémii nie sú k dispozícii"
+            "value" : "Dáta o glykémii nie sú k dispozícii"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Glukosvärden är inte tillgängliga"
+            "value" : "Inga blodglukosdata tillgängliga"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "KŞ verileri mevcut değil"
+            "value" : "Glikoz verileri kullanılamıyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дані глюкози недоступні"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dữ liệu glucose không có sẵn"
+            "value" : "Dữ liệu đường huyết không có sẵn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose data is unavailable"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "葡萄糖数据不可用"
+            "state" : "new",
+            "value" : "Glucose data is unavailable"
           }
         }
       }
@@ -361,10 +415,10 @@
     "Low Battery" : {
       "comment" : "Describes a low battery",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vybitá baterie"
+            "value" : "البطارية منخفضة"
           }
         },
         "da" : {
@@ -376,7 +430,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batterie niedrig"
+            "value" : "Batterie schwach"
           }
         },
         "es" : {
@@ -403,19 +457,19 @@
             "value" : "סוללה חלשה"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Battery"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batteria scarica"
+            "value" : "Batteria Bassa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "電池残量低下"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lavt batterinivå"
@@ -424,7 +478,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batterij Bijna Leeg"
+            "value" : "Batterij bijna leeg"
           }
         },
         "pl" : {
@@ -433,22 +487,22 @@
             "value" : "Słaba bateria"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Battery"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bateria Fraca"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baterie descărcată"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Низкий заряд батарейки"
+            "value" : "Батарейка садится"
           }
         },
         "sk" : {
@@ -469,10 +523,22 @@
             "value" : "Düşük Pil"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Низький заряд батареї"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "pin yếu"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Battery"
           }
         },
         "zh-Hans" : {
@@ -489,13 +555,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "موافق"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+            "value" : "حسناً"
           }
         },
         "da" : {
@@ -518,7 +578,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
@@ -530,8 +590,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "תקין"
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "OK"
           }
         },
         "it" : {
@@ -540,46 +606,40 @@
             "value" : "OK"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "nl" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ok"
           }
         },
-        "pl" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "OK"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OK"
+            "value" : "ОК"
           }
         },
         "sk" : {
@@ -600,16 +660,28 @@
             "value" : "Tamam"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ОК"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "好的"
+            "value" : "Ok"
           }
         }
       }
@@ -617,6 +689,12 @@
     "Peripheral command was invalid" : {
       "comment" : "invlid config error description",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أمر الجهاز الطرفي غير صالح"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -649,8 +727,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "פעולה לא חוקית"
+            "state" : "new",
+            "value" : "Peripheral command was invalid"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Peripheral command was invalid"
           }
         },
         "it" : {
@@ -659,7 +743,7 @@
             "value" : "Il comando della periferica non era valido"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Perifer kommando var ugyldig"
@@ -668,7 +752,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Perifere commando was ongeldig"
+            "value" : "Apparaat commando was ongeldig"
           }
         },
         "pl" : {
@@ -677,10 +761,16 @@
             "value" : "Polecenie urządzenia peryferyjnego było nieprawidłowe"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comanda dispozitivului este nevalidă"
+            "state" : "new",
+            "value" : "Peripheral command was invalid"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Peripheral command was invalid"
           }
         },
         "ru" : {
@@ -698,7 +788,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Perifert kommando var ogiltigt"
+            "value" : "Enhetskommando var ogiltigt"
           }
         },
         "tr" : {
@@ -706,16 +796,40 @@
             "state" : "translated",
             "value" : "Çevre birimi komutu geçersiz"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Неправильно сформовано запит."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Câu lệnh không hợp lệ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Peripheral command was invalid"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外围命令无效"
+          }
         }
       }
     },
     "Peripheral did not respond in time" : {
       "comment" : "Timeout error description",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Periferní zařízení nereagovalo včas"
+            "value" : "الجهاز الطرفي لم يستجب في الوقت المحدد"
           }
         },
         "da" : {
@@ -750,23 +864,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "לא הגיב בזמן"
+            "state" : "new",
+            "value" : "Peripheral did not respond in time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Peripheral did not respond in time"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La periferica non ha risposto in tempo"
+            "value" : "La periferica non ha risposto entro il tempo limite"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "危機が時間内に反応しませんでした"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tilbehøret svarte ikke i tide"
@@ -781,19 +895,19 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Urządzenie peryferyjne nie odpowiada"
+            "value" : "Urz. peryferyjne nie odpowiada"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Peripheral did not respond in time"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Acessório não respondeu a tempo"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dispozitivul periferic nu a răspuns în timp util"
           }
         },
         "ru" : {
@@ -811,7 +925,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enhet svarade inte inom utsatt tid"
+            "value" : "Enheten svarade inte inom utsatt tid"
           }
         },
         "tr" : {
@@ -820,10 +934,22 @@
             "value" : "Çevre birimi zamanında yanıt vermedi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Периферійний пристрій не озвався вчасно"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ngoại vi không đáp ứng kịp thời"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Peripheral did not respond in time"
           }
         },
         "zh-Hans" : {
@@ -837,6 +963,12 @@
     "Peripheral isnʼt connected" : {
       "comment" : "Not ready error description",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الجهاز الطرفي غير متصل"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -846,7 +978,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gerät ist nicht verbunden"
+            "value" : "Peripherie ist nicht verbunden"
           }
         },
         "es" : {
@@ -869,8 +1001,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "לא מחובר"
+            "state" : "new",
+            "value" : "Peripheral isnʼt connected"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Peripheral isnʼt connected"
           }
         },
         "it" : {
@@ -879,13 +1017,7 @@
             "value" : "La periferica non è connessa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "危機が接続されていません"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tilbehøret er ikke tilkoblet"
@@ -900,19 +1032,19 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Urządzenie peryferyjne nie jest podłączone"
+            "value" : "Urz. peryferyjne jest niepodłączone"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Peripheral isnʼt connected"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Acessório não está conectado"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dispozitivul periferic nu este conectat"
           }
         },
         "ru" : {
@@ -939,10 +1071,22 @@
             "value" : "Çevre birimi bağlı değil"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "З'єднання з периферійним пристроєм не встановлено"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ngoại vi không được kết nối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Peripheral isnʼt connected"
           }
         },
         "zh-Hans" : {
@@ -956,6 +1100,12 @@
     "Sensor calibration is OK" : {
       "comment" : "The description of sensor calibration state when sensor calibration is ok.",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "معايرة المستشعر مضبوطة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -965,7 +1115,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensorkalibrierung ist OK"
+            "value" : "Sensorkalibrierung OK"
           }
         },
         "es" : {
@@ -988,23 +1138,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "כיול חיישן הצליח"
+            "state" : "new",
+            "value" : "Sensor calibration is OK"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor calibration is OK"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La calibrazione del sensore è OK"
+            "value" : "La calibrazione del sensore è valida"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "センサーの較正はできています"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sensorkalibrering er OK"
@@ -1022,16 +1172,16 @@
             "value" : "Kalibracja sensora powiodła się"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor calibration is OK"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "A calibração do sensor está OK"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calibrarea senzorului este OK"
           }
         },
         "ru" : {
@@ -1043,7 +1193,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kalibrácia senzora je vporiadku"
+            "value" : "Kalibrácia senzora je v poriadku"
           }
         },
         "sv" : {
@@ -1058,10 +1208,22 @@
             "value" : "Sensör kalibrasyonu tamam"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Калібрування сенсора ОК"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hiệu chuẩn cảm biến là OK"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor calibration is OK"
           }
         },
         "zh-Hans" : {
@@ -1075,10 +1237,10 @@
     "Sensor is in unknown state %1$d" : {
       "comment" : "The description of sensor calibration state when raw value is unknown. (1: missing data details)",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Senzor je v neznámém stavu %1$d"
+            "value" : "المستشعر في حالة غير معروفة %1$d"
           }
         },
         "da" : {
@@ -1090,19 +1252,19 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensor befindet sich in unbekanntem Zustand %1$d"
+            "value" : "Sensor ist in unbekanntem Zustand %1$d"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "El sensor está en estado desconocido %1$d"
+            "value" : "El sensor está en un estado desconocido %1$d"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anturi on tuntemattomassa tilassa %1$d"
+            "state" : "new",
+            "value" : "Sensor is in unknown state %1$d"
           }
         },
         "fr" : {
@@ -1113,56 +1275,56 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מצב החיישן אינו ידוע %1$d"
+            "state" : "new",
+            "value" : "Sensor is in unknown state %1$d"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor is in unknown state %1$d"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Il sensore è in stato sconosciuto %1$d"
+            "value" : "Il Sensore è in un stato %1$d sconosciuto"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "センサーの状態が不明です %1$d"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sensor er i ukjent tilstand %1$d"
+            "value" : "Sensoren har ukjent tilstand %1$d"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Onbekende sensorstatus %1$d"
+            "value" : "Senor is in onbekende status %1$d"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sensor jest w nieznanym stanie %1$d"
+            "state" : "new",
+            "value" : "Sensor is in unknown state %1$d"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor is in unknown state %1$d"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "O sensor está em um estado desconhecido %1$d"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starea senzorului este necunoscută"
+            "state" : "new",
+            "value" : "Sensor is in unknown state %1$d"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Неизвестное состояние сенсора%1$d"
+            "value" : "Датчик находится в неизвестном состоянии %1$d"
           }
         },
         "sk" : {
@@ -1174,7 +1336,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensorns status är okänd %1$d"
+            "value" : "Sensorstatus okänd %1$d"
           }
         },
         "tr" : {
@@ -1183,16 +1345,28 @@
             "value" : "Sensör bilinmeyen durumda %1$d"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сенсор знаходиться в невідомому стані%1$d"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cảm biến ở trạng thái không xác định %1$d"
+            "value" : "Trạng thái cảm biến không xác định %1$d"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor is in unknown state %1$d"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "传感器处于未知状态 %1$d"
+            "state" : "new",
+            "value" : "Sensor is in unknown state %1$d"
           }
         }
       }
@@ -1200,10 +1374,10 @@
     "Sensor is stopped" : {
       "comment" : "The description of sensor calibration state when sensor sensor is stopped.",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Senzor je zastaven"
+            "value" : "المستشعر متوقف"
           }
         },
         "da" : {
@@ -1221,13 +1395,13 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "El sensor está en pausa"
+            "value" : "El sensor está parado"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anturi on pysäytetty"
+            "state" : "new",
+            "value" : "Sensor is stopped"
           }
         },
         "fr" : {
@@ -1238,14 +1412,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "חיישן נעצר"
+            "state" : "new",
+            "value" : "Sensor is stopped"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "सेन्सर समाप्त हो गया"
+            "state" : "new",
+            "value" : "Sensor is stopped"
           }
         },
         "it" : {
@@ -1254,46 +1428,40 @@
             "value" : "Il sensore è arrestato"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "センサーが停止しています"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sensor er stoppet"
+            "value" : "Sensoren er stoppet"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensor gestopt"
+            "value" : "Sensor is gestopt"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sensor został zatrzymany"
+            "state" : "new",
+            "value" : "Sensor is stopped"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor is stopped"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "O sensor está parado"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Senzorul e oprit"
+            "state" : "new",
+            "value" : "Sensor is stopped"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Сенсор остановлен"
+            "value" : "Датчик остановлен"
           }
         },
         "sk" : {
@@ -1311,19 +1479,31 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensör durdu"
+            "value" : "Sensör durduruldu"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сенсор зупинений"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cảm biến bị dừng"
+            "value" : "Cảm biến đã dừng hoạt động"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor is stopped"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "传感器停止"
+            "state" : "new",
+            "value" : "Sensor is stopped"
           }
         }
       }
@@ -1331,10 +1511,10 @@
     "Sensor is warming up" : {
       "comment" : "The description of sensor calibration state when sensor sensor is warming up.",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Senzor se zahřívá"
+            "value" : "المستشعر تحت الإحماء"
           }
         },
         "da" : {
@@ -1346,85 +1526,79 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensor befindet sich in der Aufwärmphase"
+            "value" : "Sensor ist in der Aufwärmphase"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "El sensor se está calentando"
+            "value" : "El sensor está calentando"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anturi lämpenee"
+            "state" : "new",
+            "value" : "Sensor is warming up"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le capteur est en préchauffage"
+            "value" : "Capteur est en période de réchauffement"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "חיישן מתכונן"
+            "state" : "new",
+            "value" : "Sensor is warming up"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "सेन्सर अपने शुरुआती समय में है"
+            "state" : "new",
+            "value" : "Sensor is warming up"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Il sensore si sta riscaldando"
+            "value" : "Il sensore è in fase di avvio"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "センサーが準備中です"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sensor varmer opp"
+            "value" : "Sensoren varmer opp"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensor aan het opwarmen"
+            "value" : "Sensor is aan het opwarmen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sensor jest w fazie rozruchu"
+            "state" : "new",
+            "value" : "Sensor is warming up"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor is warming up"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "O sensor está aquecendo"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Senzorul se pregătește"
+            "state" : "new",
+            "value" : "Sensor is warming up"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Сенсор прогревается"
+            "value" : "Датчик прогревается"
           }
         },
         "sk" : {
@@ -1436,7 +1610,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensorn värmer upp"
+            "value" : "Sensorn värms upp"
           }
         },
         "tr" : {
@@ -1445,16 +1619,28 @@
             "value" : "Sensör ısınıyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сенсор прогрівається"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cảm biến đang nóng lên"
+            "value" : "Cảm biến đang khởi động"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor is warming up"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "传感器在启动中"
+            "state" : "new",
+            "value" : "Sensor is warming up"
           }
         }
       }
@@ -1462,10 +1648,16 @@
     "Sensor needs calibration" : {
       "comment" : "The description of sensor calibration state when sensor needs calibration.",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المستشعر بحاجة الى معايرة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensoren har brug for kalibrering"
+            "value" : "Sensor behøver kalibrering"
           }
         },
         "de" : {
@@ -1494,8 +1686,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "נדרש כיול לחיישן"
+            "state" : "new",
+            "value" : "Sensor needs calibration"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor needs calibration"
           }
         },
         "it" : {
@@ -1504,13 +1702,7 @@
             "value" : "Il sensore necessita di calibrazione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "センサーの較正が必要です"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sensor trenger kalibrering"
@@ -1528,16 +1720,16 @@
             "value" : "Sensor wymaga kalibracji"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor needs calibration"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "O sensor precisa de calibração"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Senzorul are nevoie de calibrare"
           }
         },
         "ru" : {
@@ -1564,10 +1756,22 @@
             "value" : "Sensörün kalibrasyona ihtiyacı var"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сенсор вимагає калібрування"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cảm biến cần hiệu chuẩn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor needs calibration"
           }
         },
         "zh-Hans" : {
@@ -1581,6 +1785,12 @@
     "Unknown characteristic" : {
       "comment" : "Error description",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خاصية مجهولة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1617,19 +1827,19 @@
             "value" : "מאפיין לא ידוע"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown characteristic"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caratteristica sconosciuta"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エラー不明"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ukjent karakteristikk"
@@ -1647,16 +1857,16 @@
             "value" : "Nieznany błąd"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown characteristic"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Característica Desconhecida"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caracteristică necunoscută"
           }
         },
         "ru" : {
@@ -1683,10 +1893,22 @@
             "value" : "Bilinmeyen karakteristik"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невідома характеристика"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đặc điểm không xác định"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown characteristic"
           }
         },
         "zh-Hans" : {

--- a/CGMBLEKitUI/Localizable.xcstrings
+++ b/CGMBLEKitUI/Localizable.xcstrings
@@ -5,10 +5,10 @@
       "comment" : "Format string for glucose trend per minute. (1: glucose value and unit)",
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@/min"
+            "value" : "%@ دقيقة"
           }
         },
         "da" : {
@@ -37,41 +37,35 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@/min"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@/min"
+            "value" : "%@min"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@/דקה"
+            "state" : "new",
+            "value" : "%@/min"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@/मिनट"
+            "state" : "new",
+            "value" : "%@/min"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@/min"
+            "value" : "%@/minuto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@/分"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@/min"
@@ -85,20 +79,20 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%@/min"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@/min"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@/min"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "/min"
           }
         },
         "ru" : {
@@ -110,7 +104,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ /min"
+            "value" : "%@/min"
           }
         },
         "sv" : {
@@ -122,19 +116,31 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@/dk"
+            "value" : "%@/dak"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@/хв"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@/phút"
+            "value" : "%@/phút"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@/min"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@/分钟"
+            "state" : "new",
+            "value" : "%@/min"
           }
         }
       }
@@ -144,8 +150,8 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "هل أنت متأكد أنك تريد حذف هذا CGM؟"
+            "state" : "new",
+            "value" : "Are you sure you want to delete this CGM?"
           }
         },
         "da" : {
@@ -157,19 +163,19 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bist Du sicher, dass Du dieses CGM löschen möchtest?"
+            "value" : "Möchten Sie das CGM wirklich löschen?"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Está seguro de que quiere eliminar este MCG?"
+            "value" : "¿Está usted seguro de querer eliminar este MCG?"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haluatko varmasti poistaa CGM:n?"
+            "state" : "new",
+            "value" : "Are you sure you want to delete this CGM?"
           }
         },
         "fr" : {
@@ -180,74 +186,80 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "בטוח שברצונך למחוק את חיישן זה?"
+            "state" : "new",
+            "value" : "Are you sure you want to delete this CGM?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete this CGM?"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sei sicuro di voler eliminare questo CGM?"
+            "value" : "Sei sicuro di voler cancellare questo CGM?"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "このCGMを削除しますか?"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Er du sikker på at du vil slette CGM?"
+            "value" : "Sikker på at du vil slette denne CGM?"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Weet je zeker dat je deze CGM wilt verwijderen"
+            "value" : "Weet je zeker dat je deze CGM wilt vewijderen?"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Czy na pewno chcesz usunąć ten CGM?"
+            "state" : "new",
+            "value" : "Are you sure you want to delete this CGM?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete this CGM?"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Você está certo que quer remover este CGM?"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sunteți sigur că doriți să ștergeți acest CGM?"
+            "state" : "new",
+            "value" : "Are you sure you want to delete this CGM?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Вы уверены, что хотите удалить этот CGM?"
+            "value" : "Вы уверены, что хотите удалить текущий CGM?"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Naozaj chcete odstrániť toto CGM?"
+            "value" : "Ste si istí, že chcete odstrániť tento CGM?"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Är du säker på att du vill radera denna CGM?"
+            "value" : "År du säker på att du vill ta bort denna CGM?"
           }
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete this CGM?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Bu CGM'i silmek istediğinizden emin misiniz?"
+            "value" : "Ви впевнені, що хочете видалити цей CGM?"
           }
         },
         "vi" : {
@@ -256,10 +268,16 @@
             "value" : "Bạn có chắc sẽ xóa CGM này?"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete this CGM?"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "确认要删除该CGM吗？"
+            "state" : "new",
+            "value" : "Are you sure you want to delete this CGM?"
           }
         }
       }
@@ -271,12 +289,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إلغاء"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zrušit"
           }
         },
         "da" : {
@@ -300,7 +312,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kumoa"
+            "value" : "Peru"
           }
         },
         "fr" : {
@@ -311,29 +323,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "לא"
+            "state" : "new",
+            "value" : "Cancel"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "निरस्त"
+            "value" : "Mégse"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annulla"
+            "value" : "Cancella"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャンセル"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avbryt"
@@ -351,16 +357,16 @@
             "value" : "Anuluj"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancelar"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Renunță"
+            "value" : "Cancelar"
           }
         },
         "ru" : {
@@ -384,13 +390,25 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İptal"
+            "value" : "Vazgeç"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відмінити"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hủy bỏ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel"
           }
         },
         "zh-Hans" : {
@@ -404,6 +422,12 @@
     "Date" : {
       "comment" : "Title describing glucose date",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التاريخ"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -425,7 +449,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aika"
+            "value" : "Päivä"
           }
         },
         "fr" : {
@@ -436,8 +460,14 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Date"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "תאריך"
+            "value" : "Dátum"
           }
         },
         "it" : {
@@ -446,13 +476,7 @@
             "value" : "Data"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日付"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dato"
@@ -470,13 +494,13 @@
             "value" : "Data"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Data"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Data"
@@ -497,7 +521,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tid"
+            "value" : "Datum"
           }
         },
         "tr" : {
@@ -506,10 +530,22 @@
             "value" : "Tarih"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ngày"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Date"
           }
         },
         "zh-Hans" : {
@@ -526,7 +562,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "حذف CGM"
+            "value" : "حذف المستشعر"
           }
         },
         "da" : {
@@ -549,35 +585,35 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista CGM"
+            "state" : "new",
+            "value" : "Delete CGM"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Supprimer le CGM"
+            "value" : "Supprimer CGM"
           }
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete CGM"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "מחק חיישן"
+            "value" : "CGM kitörlése"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Elimina CGM"
+            "value" : "Cancella CGM"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CGMを削除"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Slett CGM"
@@ -591,32 +627,32 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuń CGM"
+            "state" : "new",
+            "value" : "Delete CGM"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete CGM"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover CGM"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ștergeți CGM"
+            "state" : "new",
+            "value" : "Delete CGM"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Удалить мониторинг"
+            "value" : "Удалить CGM"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Odstrániť CGM"
+            "value" : "Odstrániť senzor"
           }
         },
         "sv" : {
@@ -628,7 +664,13 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "CGM Sil"
+            "value" : "CGM'i Sil"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видалити CGM"
           }
         },
         "vi" : {
@@ -637,10 +679,16 @@
             "value" : "Xóa CGM"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete CGM"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "删除CGM"
+            "value" : "删除CGM数据源"
           }
         }
       }
@@ -650,14 +698,8 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "قراءات السكر"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Glukóza"
+            "state" : "new",
+            "value" : "Glucose"
           }
         },
         "da" : {
@@ -680,8 +722,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Glukoosi"
+            "state" : "new",
+            "value" : "Glucose"
           }
         },
         "fr" : {
@@ -692,29 +734,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "גלוקוז"
+            "state" : "new",
+            "value" : "Glucose"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "शुगर"
+            "value" : "Glükóz"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Glicemia"
+            "value" : "Glicemie"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "血糖値"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Blodsukker"
@@ -723,25 +759,25 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Glucose"
+            "value" : "Glucosewaarde"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Glukoza"
+            "state" : "new",
+            "value" : "Glucose"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Glicose"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Glucoza"
           }
         },
         "ru" : {
@@ -765,13 +801,25 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kan şekeri"
+            "value" : "Glikoz"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Глюкоза"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đường huyết"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose"
           }
         },
         "zh-Hans" : {
@@ -785,6 +833,12 @@
     "Glucose (Adjusted)" : {
       "comment" : "Describes a glucose value adjusted to reflect a recent calibration",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جلوكوز (معدّلة)"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -800,7 +854,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Glucose (Adjusted)"
+            "value" : "Glucosa (ajustada)"
           }
         },
         "fi" : {
@@ -817,23 +871,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "גלוקוז (מתואם)"
+            "state" : "new",
+            "value" : "Glucose (Adjusted)"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose (Adjusted)"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Glucosio (aggiustate)"
+            "value" : "Glicemie (Corrette)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "グルコース (調整後)"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Blodsukker (Justert)"
@@ -851,16 +905,16 @@
             "value" : "Glukoza (skorygowana)"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose (Adjusted)"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Glicose (Ajustada)"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Glucoză (ajustată)"
           }
         },
         "ru" : {
@@ -887,10 +941,22 @@
             "value" : "KŞ (Düzeltilmiş)"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Глюкоза (коригована)"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đường huyết (Được điều chỉnh)"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose (Adjusted)"
           }
         },
         "zh-Hans" : {
@@ -904,6 +970,12 @@
     "Latest Calibration" : {
       "comment" : "Section title for latest glucose calibration",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أحدث معايرة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -936,8 +1008,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "כיול אחרון"
+            "state" : "new",
+            "value" : "Latest Calibration"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Latest Calibration"
           }
         },
         "it" : {
@@ -946,13 +1024,7 @@
             "value" : "Ultima calibrazione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "直近の較正"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Siste kalibrering"
@@ -961,7 +1033,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Laatste Kalibratie"
+            "value" : "Laatste kalibratie"
           }
         },
         "pl" : {
@@ -970,16 +1042,16 @@
             "value" : "Ostatnia kalibracja"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Latest Calibration"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Última Calibração"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultima calibrare"
           }
         },
         "ru" : {
@@ -1006,10 +1078,22 @@
             "value" : "Son Kalibrasyon"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Остання калібровка"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lần hiệu chỉnh gần nhất"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Latest Calibration"
           }
         },
         "zh-Hans" : {
@@ -1023,6 +1107,12 @@
     "Latest Connection" : {
       "comment" : "Section title for latest connection date",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آخر اتصال"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1059,13 +1149,19 @@
             "value" : "חיבור אחרון"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Latest Connection"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ultima connessione"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Siste forbindelse"
@@ -1074,7 +1170,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Laatste Verbinding"
+            "value" : "Laatste verbinding"
           }
         },
         "pl" : {
@@ -1083,10 +1179,16 @@
             "value" : "Ostatnie połączenie"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultima conexiune"
+            "state" : "new",
+            "value" : "Latest Connection"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Latest Connection"
           }
         },
         "ru" : {
@@ -1113,10 +1215,28 @@
             "value" : "Son Bağlantı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Останнє підключення"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối mới nhất"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Latest Connection"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最新连接"
+            "value" : "上一次连接"
           }
         }
       }
@@ -1124,6 +1244,12 @@
     "Latest Reading" : {
       "comment" : "Section title for latest glucose reading",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "آخر قراءة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1156,8 +1282,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "קריאה אחרונה"
+            "state" : "new",
+            "value" : "Latest Reading"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Latest Reading"
           }
         },
         "it" : {
@@ -1166,13 +1298,7 @@
             "value" : "Ultima lettura"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最新の読み取り"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Siste måling"
@@ -1181,7 +1307,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Laatste Meting"
+            "value" : "Laatste meting"
           }
         },
         "pl" : {
@@ -1190,16 +1316,16 @@
             "value" : "Ostatni odczyt"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Latest Reading"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Leitura mais Recente"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultima citire"
           }
         },
         "ru" : {
@@ -1226,10 +1352,22 @@
             "value" : "Son Okuma"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Останнє читання"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kết quả đọc mới nhất"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Latest Reading"
           }
         },
         "zh-Hans" : {
@@ -1243,10 +1381,16 @@
     "Open App" : {
       "comment" : "Button title to open CGM app",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فتح التطبيق"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Åben app"
+            "value" : "Åbn app"
           }
         },
         "de" : {
@@ -1275,8 +1419,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "פתח אפליקציה"
+            "state" : "new",
+            "value" : "Open App"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open App"
           }
         },
         "it" : {
@@ -1285,13 +1435,7 @@
             "value" : "Apri app"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリを開く"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Åpne app"
@@ -1300,7 +1444,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Open App"
+            "value" : "App openen"
           }
         },
         "pl" : {
@@ -1309,16 +1453,16 @@
             "value" : "Otwórz aplikację"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open App"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Abrir App"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deschide aplicația"
           }
         },
         "ru" : {
@@ -1345,10 +1489,22 @@
             "value" : "Uygulamayı aç"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відкрити додаток"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mở ứng dụng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open App"
           }
         },
         "zh-Hans" : {
@@ -1362,10 +1518,16 @@
     "Remote Data Synchronization" : {
       "comment" : "Section title for remote data synchronization",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مزامنة البيانات عن بعد"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synkronisering af fjerndata"
+            "value" : "Fjerndatasynkronisering"
           }
         },
         "de" : {
@@ -1394,17 +1556,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "סנכרון נתונים מרחוק"
+            "state" : "new",
+            "value" : "Remote Data Synchronization"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remote Data Synchronization"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sincronizzazione dati remoti"
+            "value" : "Sincronizzazione dei dati remoti"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Synkronisering av eksterne data"
@@ -1413,7 +1581,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Remote Gegevenssynchronisatie"
+            "value" : "Synchronisatie van gegevens op afstand"
           }
         },
         "pl" : {
@@ -1422,10 +1590,16 @@
             "value" : "Zdalna synchronizacja danych"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizarea datelor"
+            "state" : "new",
+            "value" : "Remote Data Synchronization"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remote Data Synchronization"
           }
         },
         "ru" : {
@@ -1437,7 +1611,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Diaľková sychronizácia dát"
+            "value" : "Vzdialená sychronizácia dát"
           }
         },
         "sv" : {
@@ -1452,6 +1626,24 @@
             "value" : "Uzaktan Veri Senkronizasyonu"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Віддалена синхронізація даних"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đồng bộ hoá dữ liệu từ xa"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remote Data Synchronization"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1463,6 +1655,12 @@
     "Sensor Expired" : {
       "comment" : "Title describing past sensor sensor expiration",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إنتهت صلاحية المستشعر"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1481,6 +1679,12 @@
             "value" : "Sensor caducado"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor Expired"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1489,8 +1693,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "המשדר פג"
+            "state" : "new",
+            "value" : "Sensor Expired"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor Expired"
           }
         },
         "it" : {
@@ -1499,7 +1709,7 @@
             "value" : "Sensore scaduto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sensor utløpt"
@@ -1508,7 +1718,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensor Verlopen"
+            "value" : "Sensor verlopen"
           }
         },
         "pl" : {
@@ -1517,10 +1727,16 @@
             "value" : "Sensor wygasł"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Senzorul a expirat"
+            "state" : "new",
+            "value" : "Sensor Expired"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor Expired"
           }
         },
         "ru" : {
@@ -1535,10 +1751,34 @@
             "value" : "Platnosť senzora vypršala"
           }
         },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sensor har gått ut"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sensörün Süresi Doldu"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сенсор минув"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cảm biến đã hết hạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor Expired"
           }
         },
         "zh-Hans" : {
@@ -1552,6 +1792,12 @@
     "Sensor Expires" : {
       "comment" : "Title describing sensor sensor expiration",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ينتهي المستشعر"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1561,13 +1807,19 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensor-Ablaufzeitpunkt"
+            "value" : "Sensor läuft ab"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "El sensor caduca"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor Expires"
           }
         },
         "fr" : {
@@ -1578,8 +1830,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "תפוגת משדר"
+            "state" : "new",
+            "value" : "Sensor Expires"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor Expires"
           }
         },
         "it" : {
@@ -1588,7 +1846,7 @@
             "value" : "Scadenza sensore"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sensor utløper"
@@ -1597,7 +1855,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sensor Verloopt"
+            "value" : "Sensor verloopt"
           }
         },
         "pl" : {
@@ -1606,10 +1864,16 @@
             "value" : "Sensor Wygasa"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Senzorul expiră"
+            "state" : "new",
+            "value" : "Sensor Expires"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor Expires"
           }
         },
         "ru" : {
@@ -1621,7 +1885,13 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Platnosť senzora vyprší"
+            "value" : "Platnosť senzora skončí"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sensor går ut"
           }
         },
         "tr" : {
@@ -1630,10 +1900,28 @@
             "value" : "Sensörün Süresi Doluyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сенсор закінчується"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cảm biến hết hạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sensor Expires"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "传感器即将过期"
+            "value" : "传感器已过期"
           }
         }
       }
@@ -1641,10 +1929,16 @@
     "Session Age" : {
       "comment" : "Title describing sensor session age",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عمر الجلسة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session-alder"
+            "value" : "Sessionsalder"
           }
         },
         "de" : {
@@ -1673,23 +1967,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "זמן משדר"
+            "state" : "new",
+            "value" : "Session Age"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Session Age"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Durata sessione"
+            "value" : "Età sessione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セッション経過時間"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alder på økt"
@@ -1707,16 +2001,16 @@
             "value" : "Wiek sesji"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Session Age"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Idade da Sessão"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vechime sesiune"
           }
         },
         "ru" : {
@@ -1743,10 +2037,22 @@
             "value" : "Sensör Yaşı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вік Сенсору"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thời gian sử dụng sensor"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Session Age"
           }
         },
         "zh-Hans" : {
@@ -1764,12 +2070,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الحالة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status"
           }
         },
         "da" : {
@@ -1804,8 +2104,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מצב"
+            "state" : "new",
+            "value" : "Status"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Status"
           }
         },
         "it" : {
@@ -1814,13 +2120,7 @@
             "value" : "Stato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ステータス"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Status"
@@ -1834,7 +2134,13 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Status"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Status"
           }
         },
@@ -1842,12 +2148,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Estado"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stare"
           }
         },
         "ru" : {
@@ -1874,10 +2174,22 @@
             "value" : "Durum"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статус"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tình trạng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Status"
           }
         },
         "zh-Hans" : {
@@ -1891,10 +2203,16 @@
     "Transmitter Age" : {
       "comment" : "Title describing transmitter session age",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عمر جهاز الإرسال"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sender alder"
+            "value" : "Senderalder"
           }
         },
         "de" : {
@@ -1923,23 +2241,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "גיל משדר"
+            "state" : "new",
+            "value" : "Transmitter Age"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter Age"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Durata trasmettitore"
+            "value" : "Età trasmettitore"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "トランスミッター経過時間"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alder på sender"
@@ -1957,16 +2275,16 @@
             "value" : "Wiek nadajnika"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter Age"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Idade do Transmissor"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vechime transmițător"
           }
         },
         "ru" : {
@@ -1993,10 +2311,22 @@
             "value" : "Verici Yaşı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Трансмітер відпрацював"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Thời gian sử dụng Transmitter"
+            "value" : "Transmitter đã sử dụng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter Age"
           }
         },
         "zh-Hans" : {
@@ -2010,6 +2340,12 @@
     "Transmitter ID" : {
       "comment" : "The title text for the Dexcom G5/G6 transmitter ID config value",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "معرف المرسل"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2019,19 +2355,19 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Transmitter-ID"
+            "value" : "Sender-ID"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Identificación del transmisor"
+            "value" : "ID del transmisor"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lähettimen tunniste"
+            "state" : "new",
+            "value" : "Transmitter ID"
           }
         },
         "fr" : {
@@ -2042,8 +2378,14 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter ID"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "מזהה משדר"
+            "value" : "Jeladó ID"
           }
         },
         "it" : {
@@ -2052,40 +2394,34 @@
             "value" : "ID trasmettitore"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "トランスミッタ ID"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sender ID"
+            "value" : "Sender-ID"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zenderserienummer"
+            "value" : "Zender ID"
           }
         },
         "pl" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter ID"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "ID nadajnika"
+            "value" : "ID do transmissor"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ID do Transmissor"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID transmițător"
+            "value" : "ID do transmissor"
           }
         },
         "ru" : {
@@ -2103,19 +2439,31 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sändari-ID"
+            "value" : "Sändar-ID"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verici Kimliği"
+            "value" : "Verici ID"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID передавача"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Số ID của Transmitter"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Transmitter ID"
           }
         },
         "zh-Hans" : {
@@ -2129,6 +2477,12 @@
     "Trend" : {
       "comment" : "Title describing glucose trend",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إتجاه"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2149,8 +2503,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suunta"
+            "state" : "new",
+            "value" : "Trend"
           }
         },
         "fr" : {
@@ -2161,14 +2515,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מגמה"
+            "state" : "new",
+            "value" : "Trend"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ट्रेंड"
+            "state" : "new",
+            "value" : "Trend"
           }
         },
         "it" : {
@@ -2177,13 +2531,7 @@
             "value" : "Tendenza"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "トレンド"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trend"
@@ -2197,20 +2545,20 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Trend"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Trend"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tendência"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tendinţă"
+            "state" : "new",
+            "value" : "Trend"
           }
         },
         "ru" : {
@@ -2222,7 +2570,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Trend"
+            "value" : "Vývoj"
           }
         },
         "sv" : {
@@ -2237,16 +2585,28 @@
             "value" : "Eğilim"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тренди"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xu hướng"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Trend"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "趋势"
+            "state" : "new",
+            "value" : "Trend"
           }
         }
       }
@@ -2254,6 +2614,12 @@
     "Upload Readings" : {
       "comment" : "The title text for the upload glucose switch cell",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رفع القراءات"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2269,13 +2635,13 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Subir Datos"
+            "value" : "Subir lecturas"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lataa lukemat"
+            "state" : "new",
+            "value" : "Upload Readings"
           }
         },
         "fr" : {
@@ -2286,23 +2652,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "העלה נתונים"
+            "state" : "new",
+            "value" : "Upload Readings"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "अपलोड रीडिंग्स"
+            "state" : "new",
+            "value" : "Upload Readings"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Carica letture"
+            "value" : "Carica Letture"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Last opp avlesninger"
@@ -2311,37 +2677,43 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Upload Metingen"
+            "value" : "Lezingen uploaden"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wysyłaj odczyty"
+            "state" : "new",
+            "value" : "Upload Readings"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Urcă citirile de glicemie"
+            "state" : "new",
+            "value" : "Upload Readings"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Upload Readings"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Загрузить показания"
+            "value" : "Выгружать данные"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Načítať údaje"
+            "value" : "Nahrať merania"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ladda upp avläsningar"
+            "value" : "Ladda upp blodsocker"
           }
         },
         "tr" : {
@@ -2350,10 +2722,28 @@
             "value" : "Okumaları Yükle"
           }
         },
-        "zh-Hans" : {
+        "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "上传读数"
+            "value" : "Вивантажити читання"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Glucose đang tải lên"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Upload Readings"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Upload Readings"
           }
         }
       }

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,10 @@
+files:
+  - source: /CGMBLEKit/Localizable.xcstrings
+    translation: /CGMBLEKit/Localizable.xcstrings
+    multilingual: 1
+  - source: /CGMBLEKitUI/Localizable.xcstrings
+    translation: /CGMBLEKitUI/Localizable.xcstrings
+    multilingual: 1
+  - source: /CGMBLEKitUI/mul.lproj/TransmitterManagerSetup.xcstrings
+    translation: /CGMBLEKit/CGMBLEKitUI/mul.lproj/TransmitterManagerSetup.xcstrings
+    multilingual: 1


### PR DESCRIPTION
Swedish and Dutch 100% and other languages not fully completed.   Created with Crowdin (= no parsing errors). 

Unfortunately there is also be an added configuration file, crowdin.yml. This file is only used by Crowdin, meaning it will not mess anything up with lokalise or the Loop Workspace. You can ignore it, when merging, but it would be easier to keep it (for future PRs).