### PR TITLE
Enable upload G6 to remote as the default value

### DIFF
--- a/CGMBLEKit/TransmitterManagerState.swift
+++ b/CGMBLEKit/TransmitterManagerState.swift
@@ -26,7 +26,7 @@ public struct TransmitterManagerState: RawRepresentable, Equatable {
 
     public init(
         transmitterID: String,
-        shouldSyncToRemoteService: Bool = false,
+        shouldSyncToRemoteService: Bool = true,
         transmitterStartDate: Date? = nil,
         sensorStartOffset: UInt32? = nil
     ) {


### PR DESCRIPTION
## Purpose:

Modify the default value for `shouldSyncToRemoteService` to be true instead of false.

Most users who use G6 / ONE with Nightscout want this to be true. Frequently, they forgot to enable it again when they switch transmitters. By making the default true, this issue will be solved.

## Test

Build using this PR.
Add G6 / ONE as a CGM.
Enter 6 random values to get past the transmitter screen
Confirm the Upload Readings is enabled by default.

