### PR TITLE
Handle inactive CGM sensor sessions

### DIFF
--- a/CGMBLEKit/Glucose.swift
+++ b/CGMBLEKit/Glucose.swift
@@ -49,8 +49,14 @@ public struct Glucose {
         self.status = TransmitterStatus(rawValue: status)
         self.activationDate = activationDate
 
-        sessionStartDate = activationDate.addingTimeInterval(TimeInterval(timeMessage.sessionStartTime))
-        sessionExpDate = activationDate.addingTimeInterval(TimeInterval(timeMessage.sessionStartTime) + (10*24*60*60))
+        if timeMessage.hasValidSensorSession {
+            let sessionStartDate = activationDate.addingTimeInterval(TimeInterval(timeMessage.sessionStartTime))
+            self.sessionStartDate = sessionStartDate
+            self.sessionExpDate = sessionStartDate.addingTimeInterval(10*24*60*60)
+        } else {
+            sessionStartDate = nil
+            sessionExpDate = nil
+        }
         readDate = activationDate.addingTimeInterval(TimeInterval(glucoseMessage.timestamp))
         lastCalibration = calibrationMessage != nil ? Calibration(calibrationMessage: calibrationMessage!, activationDate: activationDate) : nil
     }
@@ -59,8 +65,12 @@ public struct Glucose {
     public let transmitterID: String
     public let status: TransmitterStatus
     public let activationDate: Date
-    public let sessionStartDate: Date
-    public let sessionExpDate: Date
+    public let sessionStartDate: Date?
+    public let sessionExpDate: Date?
+
+    public var hasValidSensorSession: Bool {
+        return sessionStartDate != nil
+    }
 
     // MARK: - Glucose Info
     public let lastCalibration: Calibration?

--- a/CGMBLEKit/Messages/TransmitterTimeRxMessage.swift
+++ b/CGMBLEKit/Messages/TransmitterTimeRxMessage.swift
@@ -10,9 +10,16 @@ import Foundation
 
 
 struct TransmitterTimeRxMessage: TransmitterRxMessage {
+    // Dexcom reports UInt32.max when no sensor session is active.
+    static let noActiveSessionStartTime = UInt32.max
+
     let status: UInt8
     let currentTime: UInt32
     let sessionStartTime: UInt32
+
+    var hasValidSensorSession: Bool {
+        return sessionStartTime != Self.noActiveSessionStartTime && sessionStartTime <= currentTime
+    }
 
     init?(data: Data) {
         guard data.count == 16 && data.isCRCValid else {

--- a/CGMBLEKit/TransmitterManager.swift
+++ b/CGMBLEKit/TransmitterManager.swift
@@ -59,8 +59,15 @@ public class TransmitterManager: TransmitterDelegate {
 
 
     public var hasValidSensorSession: Bool {
-        // TODO: we should decode and persist transmitter session state
-        return !state.transmitterID.isEmpty
+        if let latestReading = latestReading {
+            return latestReading.hasValidSensorSession
+        }
+
+        if let sensorStartOffset = state.sensorStartOffset {
+            return sensorStartOffset != TransmitterTimeRxMessage.noActiveSessionStartTime
+        }
+
+        return false
     }
     
     public var cgmManagerStatus: CGMManagerStatus {
@@ -322,17 +329,24 @@ public class TransmitterManager: TransmitterDelegate {
             ))
         }
 
-        if state.sensorStartOffset != glucose.timeMessage.sessionStartTime {
+        let sensorStartOffset = glucose.timeMessage.hasValidSensorSession
+            ? glucose.timeMessage.sessionStartTime
+            : TransmitterTimeRxMessage.noActiveSessionStartTime
+        if state.sensorStartOffset != sensorStartOffset {
             mutateState { state in
-                state.sensorStartOffset = glucose.timeMessage.sessionStartTime
+                state.sensorStartOffset = sensorStartOffset
             }
-            events.append(PersistedCgmEvent(
-                date: glucose.sessionStartDate,
-                type: .sensorStart,
-                deviceIdentifier: transmitter.ID,
-                expectedLifetime: .hours(24 * 10),
-                warmupPeriod: .hours(2)
-            ))
+            if let sessionStartDate = glucose.sessionStartDate {
+                events.append(PersistedCgmEvent(
+                    date: sessionStartDate,
+                    type: .sensorStart,
+                    deviceIdentifier: transmitter.ID,
+                    expectedLifetime: .hours(24 * 10),
+                    warmupPeriod: .hours(2)
+                ))
+            } else {
+                log.error("Ignoring sensor start event with invalid session start time: %{public}@", String(describing: glucose))
+            }
         }
 
         // Filter out future-dated events
@@ -577,4 +591,3 @@ extension G6CGMManager {
     public func getSoundBaseURL() -> URL? { return nil }
     public func getSounds() -> [Alert.Sound] { return [] }
 }
-

--- a/CGMBLEKitTests/GlucoseTests.swift
+++ b/CGMBLEKitTests/GlucoseTests.swift
@@ -34,11 +34,28 @@ class GlucoseTests: XCTestCase {
 
         XCTAssertEqual(TransmitterStatus.ok, glucose.status)
         XCTAssertEqual(calendar.date(from: DateComponents(year: 2016, month: 12, day: 6, hour: 7, minute: 51, second: 38))!, glucose.readDate)
-        XCTAssertEqual(calendar.date(from: DateComponents(year: 2016, month: 12, day: 26, hour: 11, minute: 16, second: 12))!, glucose.sessionStartDate)
+        XCTAssertEqual(calendar.date(from: DateComponents(year: 2016, month: 12, day: 26, hour: 11, minute: 16, second: 12)), glucose.sessionStartDate)
+        XCTAssertEqual(calendar.date(from: DateComponents(year: 2017, month: 1, day: 5, hour: 11, minute: 16, second: 12)), glucose.sessionExpDate)
+        XCTAssertTrue(glucose.hasValidSensorSession)
         XCTAssertFalse(glucose.isDisplayOnly)
         XCTAssertEqual(204, glucose.glucose?.doubleValue(for: .milligramsPerDeciliter))
         XCTAssertEqual(.known(.ok), glucose.state)
         XCTAssertEqual(-1, glucose.trend)
+    }
+
+    func testNoSessionDoesNotDeriveFutureSessionDates() {
+        let timeData = Data(hexadecimalString: "2500e8f87100ffffffff010000000a70")!
+        let noSessionTimeMessage = TransmitterTimeRxMessage(data: timeData)!
+
+        let data = Data(hexadecimalString: "3100680a00008a715700cc0006ffc42a")!
+        let message = GlucoseRxMessage(data: data)!
+        let glucose = Glucose(transmitterID: "123456", glucoseMessage: message, timeMessage: noSessionTimeMessage, activationDate: activationDate)
+
+        XCTAssertFalse(noSessionTimeMessage.hasValidSensorSession)
+        XCTAssertFalse(glucose.hasValidSensorSession)
+        XCTAssertNil(glucose.sessionStartDate)
+        XCTAssertNil(glucose.sessionExpDate)
+        XCTAssertEqual(calendar.date(from: DateComponents(year: 2016, month: 12, day: 6, hour: 7, minute: 51, second: 38))!, glucose.readDate)
     }
 
     func testNegativeTrend() {

--- a/CGMBLEKitTests/TransmitterTimeRxMessageTests.swift
+++ b/CGMBLEKitTests/TransmitterTimeRxMessageTests.swift
@@ -19,6 +19,7 @@ class TransmitterTimeRxMessageTests: XCTestCase {
         XCTAssertEqual(0, message.status)
         XCTAssertEqual(7469288, message.currentTime)
         XCTAssertEqual(0xffffffff, message.sessionStartTime)
+        XCTAssertFalse(message.hasValidSensorSession)
 
         data = Data(hexadecimalString: "250096fd7100ffffffff01000000226d")!
         message = TransmitterTimeRxMessage(data: data)!
@@ -26,6 +27,7 @@ class TransmitterTimeRxMessageTests: XCTestCase {
         XCTAssertEqual(0, message.status)
         XCTAssertEqual(7470486, message.currentTime)
         XCTAssertEqual(0xffffffff, message.sessionStartTime)
+        XCTAssertFalse(message.hasValidSensorSession)
 
         data = Data(hexadecimalString: "2500eeff7100ffffffff010000008952")!
         message = TransmitterTimeRxMessage(data: data)!
@@ -33,6 +35,7 @@ class TransmitterTimeRxMessageTests: XCTestCase {
         XCTAssertEqual(0, message.status)
         XCTAssertEqual(7471086, message.currentTime)
         XCTAssertEqual(0xffffffff, message.sessionStartTime)
+        XCTAssertFalse(message.hasValidSensorSession)
     }
 
     func testInSession() {
@@ -42,6 +45,7 @@ class TransmitterTimeRxMessageTests: XCTestCase {
         XCTAssertEqual(0, message.status)
         XCTAssertEqual(7471687, message.currentTime)
         XCTAssertEqual(7470972, message.sessionStartTime)
+        XCTAssertTrue(message.hasValidSensorSession)
 
         data = Data(hexadecimalString: "2500beb24d00f22d4d000100000083c0")!
         message = TransmitterTimeRxMessage(data: data)!
@@ -49,5 +53,6 @@ class TransmitterTimeRxMessageTests: XCTestCase {
         XCTAssertEqual(0, message.status)
         XCTAssertEqual(5092030, message.currentTime)
         XCTAssertEqual(5058034, message.sessionStartTime)
+        XCTAssertTrue(message.hasValidSensorSession)
     }
 }


### PR DESCRIPTION
This PR addresses the remaining part of #209 by handling Dexcom’s “no active sensor session” marker at the source.

CGMBLEKit currently receives `0xffffffff` as the session start time when there is no active sensor session. Because that value was still being treated as a real elapsed-time offset, CGMBLEKit could derive a sensor start date far in the future. Downstream apps can then see that future date as a valid `sessionStartDate`, which can lead to incorrect Nightscout CGM state uploads such as future-dated Sensor Start treatments.

#191 added a useful safety check by filtering out future-dated sensor events before they are emitted. That helps one path, but it does not fully solve the issue because downstream consumers may still read `latestReading.sessionStartDate` directly before or outside that event filtering path.

This PR moves the handling earlier:

- treats `0xffffffff` as an explicit “no active session” value
- exposes whether the transmitter time represents a valid sensor session
- avoids deriving `sessionStartDate` / `sessionExpDate` when no session is active
- keeps transmitter session state consistent with that invalid-session marker
- adds tests for both valid-session and no-session transmitter time/glucose parsing

The intent is that CGMBLEKit should not manufacture a future sensor start date when the transmitter is actually reporting that no session is active. That should prevent the bad date from leaking into downstream apps, while #191 remains useful as an additional defensive filter for any future-dated events.
